### PR TITLE
Fix hero video layering over background

### DIFF
--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -277,7 +277,8 @@ footer a:hover {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  z-index: -2;
+  /* Place the video above the background image */
+  z-index: 0;
 }
 
 /* Overlay to darken the video for better readability of text */
@@ -288,5 +289,6 @@ footer a:hover {
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.45);
-  z-index: -1;
+  /* Layer the overlay above the video */
+  z-index: 1;
 }


### PR DESCRIPTION
## Summary
- bring hero video above the fallback image
- layer the overlay above the video

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6889d9ee10488326bf41987e344f34e9