### PR TITLE
Improve event card layout

### DIFF
--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -71,7 +71,8 @@
 
 .event-card img {
   width: 100%;
-  height: 180px;
+  aspect-ratio: 1;
+  height: auto;
   object-fit: cover;
 }
 
@@ -206,14 +207,15 @@ footer a:hover {
 
 /* Ensure event images show fully within their card frame */
 /*
- * When displaying event posters or creatives, we don’t want to crop them.
- * Use object‑fit: contain and a fixed max height so each card remains the same size.
- * A light background colour ensures letterboxing around smaller images isn’t too distracting.
+ * Event images should fill their square frame similarly to an Instagram post.
+ * Using object-fit: cover with a 1/1 aspect ratio ensures the image covers the
+ * entire area while keeping the cards responsive.
  */
 #events-grid img {
   width: 100%;
-  max-height: 200px;
-  object-fit: contain;
+  aspect-ratio: 1;
+  height: auto;
+  object-fit: cover;
   background-color: #ffffff;
   border-radius: 0.5rem 0.5rem 0 0;
 }
@@ -256,9 +258,7 @@ footer a:hover {
 }
 
 @media (max-width: 575.98px) {
-  .menu-card img,
-  .event-card img,
-  #events-grid img {
+  .menu-card img {
     height: 160px;
   }
 }


### PR DESCRIPTION
## Summary
- keep event images square so they resemble Instagram posts
- remove fixed heights from event images for responsive sizing

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6889f6a325f883269794eacc8bcde016