### PR TITLE
Add events generator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ To avoid hitting GitHub API limits, a cached `events.json` file is also used.
 
 1. **Add or remove event images** in `assets/events/` using the format
    `YYYY-MM-DD-Event-Name.jpg` (or `.png`, `.webp`).
-2. **Update `events.json`** in the same folder with an array of event objects:
+2. Run `python3 scripts/generate_events_json.py` to rebuild
+   `events.json` from those filenames. The generated file will contain an
+   array of event objects like:
 
    ```json
    [

--- a/scripts/generate_events_json.py
+++ b/scripts/generate_events_json.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Generate events.json from image filenames."""
+
+import json
+import re
+from pathlib import Path
+
+EVENT_DIR = Path(__file__).resolve().parents[1] / "assets" / "events"
+PATTERN = re.compile(r"(?P<date>\d{4}-\d{2}-\d{2})-(?P<title>.+?)\.(?:jpg|png|webp)", re.IGNORECASE)
+
+
+def parse_events():
+    events = []
+    for path in sorted(EVENT_DIR.iterdir()):
+        if not path.is_file() or path.name == "events.json":
+            continue
+        m = PATTERN.match(path.name)
+        if not m:
+            continue
+        date = m.group("date")
+        title = m.group("title").replace("-", " ")
+        events.append({"date": date, "title": title, "image": path.name})
+    return events
+
+
+def main() -> None:
+    events = parse_events()
+    out_file = EVENT_DIR / "events.json"
+    with out_file.open("w", encoding="utf-8") as f:
+        json.dump(events, f, indent=2)
+        f.write("\n")
+    print(f"Wrote {len(events)} events to {out_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/generate_events_json.py` to build events metadata
- document how to run the script in the README

## Testing
- `python3 scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688a016743288326bb71cdf0ba539b02