### PR TITLE
Add events update workflow

### DIFF
--- a/.github/workflows/update-events.yml
+++ b/.github/workflows/update-events.yml
@@ -1,0 +1,33 @@
+name: Update events
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Generate events.json
+        run: python scripts/generate_events.py
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          if git status --porcelain | grep 'events.json'; then
+            git add assets/events/events.json
+            git commit -m 'chore: update events.json'
+            git push
+          else
+            echo 'No changes to commit.'
+          fi

--- a/README.md
+++ b/README.md
@@ -29,5 +29,9 @@ To avoid hitting GitHub API limits, a cached `events.json` file is also used.
    from `events.json` first and only fall back to the GitHub API if the
    file is missing or empty.
 
+The `update-events` GitHub Actions workflow can regenerate `events.json`
+automatically based on the filenames in `assets/events/` and commit any
+changes.
+
 When network errors or API limits occur, visitors will see a friendly
 "No upcoming events" message instead of the section disappearing.

--- a/scripts/generate_events.py
+++ b/scripts/generate_events.py
@@ -1,0 +1,21 @@
+import os
+import json
+import re
+
+dir_path = os.path.join('assets', 'events')
+pattern = re.compile(r'^(\d{4})-(\d{2})-(\d{2})-(.+)\.(png|jpe?g|webp)$', re.IGNORECASE)
+
+events = []
+for fname in os.listdir(dir_path):
+    m = pattern.match(fname)
+    if not m:
+        continue
+    year, month, day, title, _ = m.groups()
+    date = f"{year}-{month}-{day}"
+    title = title.replace('-', ' ').replace('_', ' ')
+    events.append({'date': date, 'title': title, 'image': fname})
+
+events.sort(key=lambda e: e['date'])
+with open(os.path.join(dir_path, 'events.json'), 'w') as f:
+    json.dump(events, f, indent=2)
+    f.write('\n')


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to auto-generate `events.json`
- create helper script for generating `events.json`
- document the automatic update in the README

## Testing
- `python scripts/generate_events.py`

------
https://chatgpt.com/codex/tasks/task_e_688a01689b3883269dfba657060a7723