### PR TITLE
Add dynamic gallery for all menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ When network errors or API limits occur, visitors will see a friendly
 ## Updating Menus
 
 Each menu page (e.g. `food-menu.html`, `bar-menu.html`, `specials-menu.html`)
-displays a simple gallery of images. Menu images live in `assets/menus/` and
-follow the naming pattern `<menu-name>-pg#.jpg` (for example,
-`food-menu-pg1.jpg`). Just add or remove images using this convention and edit
-the HTML pages if needed to include the new `<img>` tags.
+displays images stored in `assets/menus/` following the naming pattern
+`<menu-name>-pg#.jpg` (for example, `food-menu-pg1.jpg`). All menu pages load
+these images automatically, so simply add or remove files and they will appear
+in their respective galleries.

--- a/assets/js/menu-gallery.js
+++ b/assets/js/menu-gallery.js
@@ -1,0 +1,55 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const galleries = document.querySelectorAll('[data-menu-gallery]');
+  galleries.forEach(async (wrapper) => {
+    const menu = wrapper.dataset.menuGallery;
+    const imgEl = wrapper.querySelector('.menu-image');
+    const counterEl = wrapper.querySelector('.image-counter');
+    const prevBtn = wrapper.querySelector('.prev-btn');
+    const nextBtn = wrapper.querySelector('.next-btn');
+
+    async function fetchImages() {
+      const imgs = [];
+      for (let i = 1; i <= 50; i++) {
+        const url = `assets/menus/${menu}-pg${i}.jpg`;
+        try {
+          const res = await fetch(url, { method: 'HEAD' });
+          if (!res.ok) break;
+          imgs.push(url);
+        } catch (e) {
+          break;
+        }
+      }
+      return imgs;
+    }
+
+    const images = await fetchImages();
+    if (images.length === 0) {
+      wrapper.innerHTML = `<p>No ${menu.replace('-', ' ')} images available.</p>`;
+      return;
+    }
+
+    let index = 0;
+    const update = () => {
+      imgEl.src = images[index];
+      counterEl.textContent = `${index + 1} / ${images.length}`;
+      prevBtn.disabled = index === 0;
+      nextBtn.disabled = index === images.length - 1;
+    };
+
+    prevBtn.addEventListener('click', () => {
+      if (index > 0) {
+        index--;
+        update();
+      }
+    });
+
+    nextBtn.addEventListener('click', () => {
+      if (index < images.length - 1) {
+        index++;
+        update();
+      }
+    });
+
+    update();
+  });
+});

--- a/bar-menu.html
+++ b/bar-menu.html
@@ -39,14 +39,22 @@
     <main class="py-5 mt-5">
         <div class="container">
             <h1 class="text-center mb-4">Bar Menu</h1>
-            <!-- Replace the PDF viewer with a simple image gallery. Add or remove
-                 <img> tags as you create more pages named bar-menu-pg#.jpg -->
-            <div class="mb-4 text-center">
-                <p>No bar menu images available.</p>
+            <div id="barMenuGallery" data-menu-gallery="bar-menu" class="mb-4 text-center">
+                <div class="position-relative d-inline-block">
+                    <button class="prev-btn btn btn-primary position-absolute top-50 start-0 translate-middle-y" style="z-index:2">
+                        <i class="fa-solid fa-chevron-left"></i>
+                    </button>
+                    <img class="menu-image img-fluid" src="" alt="Bar Menu">
+                    <button class="next-btn btn btn-primary position-absolute top-50 end-0 translate-middle-y" style="z-index:2">
+                        <i class="fa-solid fa-chevron-right"></i>
+                    </button>
+                </div>
+                <div class="image-counter mt-2"></div>
             </div>
         </div>
     </main>
     <script src="assets/js/header.js"></script>
+    <script src="assets/js/menu-gallery.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/food-menu.html
+++ b/food-menu.html
@@ -39,23 +39,22 @@
     <main class="py-5 mt-5">
         <div class="container">
             <h1 class="text-center mb-4">Food Menu</h1>
-            <!-- Replace the PDF viewer with a simple image gallery. Add or remove
-                 <img> tags as you create more pages named food-menu-pg#.jpg -->
-            <div class="mb-4">
-                <img src="assets/menus/food-menu-pg1.jpg" alt="Food Menu page 1" class="img-fluid mb-3">
-                <img src="assets/menus/food-menu-pg2.jpg" alt="Food Menu page 2" class="img-fluid mb-3">
-                <img src="assets/menus/food-menu-pg3.jpg" alt="Food Menu page 3" class="img-fluid mb-3">
-                <img src="assets/menus/food-menu-pg4.jpg" alt="Food Menu page 4" class="img-fluid mb-3">
-                <img src="assets/menus/food-menu-pg5.jpg" alt="Food Menu page 5" class="img-fluid mb-3">
-                <img src="assets/menus/food-menu-pg6.jpg" alt="Food Menu page 6" class="img-fluid mb-3">
-                <img src="assets/menus/food-menu-pg7.jpg" alt="Food Menu page 7" class="img-fluid mb-3">
-                <img src="assets/menus/food-menu-pg8.jpg" alt="Food Menu page 8" class="img-fluid mb-3">
-                <img src="assets/menus/food-menu-pg9.jpg" alt="Food Menu page 9" class="img-fluid mb-3">
-                <img src="assets/menus/food-menu-pg10.jpg" alt="Food Menu page 10" class="img-fluid mb-3">
+            <div id="foodMenuGallery" data-menu-gallery="food-menu" class="mb-4 text-center">
+                <div class="position-relative d-inline-block">
+                    <button class="prev-btn btn btn-primary position-absolute top-50 start-0 translate-middle-y" style="z-index:2">
+                        <i class="fa-solid fa-chevron-left"></i>
+                    </button>
+                    <img class="menu-image img-fluid" src="" alt="Food Menu">
+                    <button class="next-btn btn btn-primary position-absolute top-50 end-0 translate-middle-y" style="z-index:2">
+                        <i class="fa-solid fa-chevron-right"></i>
+                    </button>
+                </div>
+                <div class="image-counter mt-2"></div>
             </div>
         </div>
     </main>
     <script src="assets/js/header.js"></script>
+    <script src="assets/js/menu-gallery.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/specials-menu.html
+++ b/specials-menu.html
@@ -39,14 +39,22 @@
     <main class="py-5 mt-5">
         <div class="container">
             <h1 class="text-center mb-4">Specials Menu</h1>
-            <!-- Replace the PDF viewer with a simple image gallery. Add or remove
-                 <img> tags as you create more pages named specials-menu-pg#.jpg -->
-            <div class="mb-4 text-center">
-                <p>No specials menu images available.</p>
+            <div id="specialsMenuGallery" data-menu-gallery="specials-menu" class="mb-4 text-center">
+                <div class="position-relative d-inline-block">
+                    <button class="prev-btn btn btn-primary position-absolute top-50 start-0 translate-middle-y" style="z-index:2">
+                        <i class="fa-solid fa-chevron-left"></i>
+                    </button>
+                    <img class="menu-image img-fluid" src="" alt="Specials Menu">
+                    <button class="next-btn btn btn-primary position-absolute top-50 end-0 translate-middle-y" style="z-index:2">
+                        <i class="fa-solid fa-chevron-right"></i>
+                    </button>
+                </div>
+                <div class="image-counter mt-2"></div>
             </div>
         </div>
     </main>
     <script src="assets/js/header.js"></script>
+    <script src="assets/js/menu-gallery.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove food-menu specific gallery script
- add general JS for loading menu galleries
- enable dynamic galleries on bar and specials menu pages
- update README to mention automatic updates for all menus

## Testing
- `python3 -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688a1ac9849c8326884b3feda9f8c1b4