### PR TITLE
Use modal for bar and specials menus

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
                         <div class="p-3">
                             <h5 class="mb-2">Bar Menu</h5>
                             <p class="small">Signature cocktails, fine wines and craft beers.</p>
-                            <a href="bar-menu.html" class="btn btn-primary">View Menu</a>
+                            <a href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#barMenuModal">View Menu</a>
                         </div>
                     </div>
                 </div>
@@ -111,7 +111,7 @@
                         <div class="p-3">
                             <h5 class="mb-2">Specials</h5>
                             <p class="small">Seasonal dishes and chef's creations.</p>
-                            <a href="specials-menu.html" class="btn btn-primary">View Menu</a>
+                            <a href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#specialsMenuModal">View Menu</a>
                         </div>
                     </div>
                 </div>
@@ -170,6 +170,89 @@
                             <span class="visually-hidden">Next</span>
                         </button>
                     </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Bar Menu Modal -->
+    <div class="modal fade" id="barMenuModal" tabindex="-1" aria-labelledby="barMenuLabel" aria-hidden="true">
+        <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="barMenuLabel">Bar Menu</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div id="barMenuCarousel" class="carousel slide" data-bs-ride="carousel">
+                        <div class="carousel-inner">
+                            <div class="carousel-item active">
+                                <img src="assets/menus/bar-menu-pg1.jpg" class="d-block w-100" alt="Bar Menu page 1">
+                            </div>
+                            <div class="carousel-item">
+                                <img src="assets/menus/bar-menu-pg2.jpg" class="d-block w-100" alt="Bar Menu page 2">
+                            </div>
+                            <div class="carousel-item">
+                                <img src="assets/menus/bar-menu-pg3.jpg" class="d-block w-100" alt="Bar Menu page 3">
+                            </div>
+                            <div class="carousel-item">
+                                <img src="assets/menus/bar-menu-pg4.jpg" class="d-block w-100" alt="Bar Menu page 4">
+                            </div>
+                            <div class="carousel-item">
+                                <img src="assets/menus/bar-menu-pg5.jpg" class="d-block w-100" alt="Bar Menu page 5">
+                            </div>
+                            <div class="carousel-item">
+                                <img src="assets/menus/bar-menu-pg6.jpg" class="d-block w-100" alt="Bar Menu page 6">
+                            </div>
+                            <div class="carousel-item">
+                                <img src="assets/menus/bar-menu-pg7.jpg" class="d-block w-100" alt="Bar Menu page 7">
+                            </div>
+                            <div class="carousel-item">
+                                <img src="assets/menus/bar-menu-pg8.jpg" class="d-block w-100" alt="Bar Menu page 8">
+                            </div>
+                            <div class="carousel-item">
+                                <img src="assets/menus/bar-menu-pg9.jpg" class="d-block w-100" alt="Bar Menu page 9">
+                            </div>
+                            <div class="carousel-item">
+                                <img src="assets/menus/bar-menu-pg10.jpg" class="d-block w-100" alt="Bar Menu page 10">
+                            </div>
+                            <div class="carousel-item">
+                                <img src="assets/menus/bar-menu-pg11.jpg" class="d-block w-100" alt="Bar Menu page 11">
+                            </div>
+                            <div class="carousel-item">
+                                <img src="assets/menus/bar-menu-pg12.jpg" class="d-block w-100" alt="Bar Menu page 12">
+                            </div>
+                            <div class="carousel-item">
+                                <img src="assets/menus/bar-menu-pg13.jpg" class="d-block w-100" alt="Bar Menu page 13">
+                            </div>
+                            <div class="carousel-item">
+                                <img src="assets/menus/bar-menu-pg14.jpg" class="d-block w-100" alt="Bar Menu page 14">
+                            </div>
+                        </div>
+                        <button class="carousel-control-prev" type="button" data-bs-target="#barMenuCarousel" data-bs-slide="prev">
+                            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
+                            <span class="visually-hidden">Previous</span>
+                        </button>
+                        <button class="carousel-control-next" type="button" data-bs-target="#barMenuCarousel" data-bs-slide="next">
+                            <span class="carousel-control-next-icon" aria-hidden="true"></span>
+                            <span class="visually-hidden">Next</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Specials Menu Modal -->
+    <div class="modal fade" id="specialsMenuModal" tabindex="-1" aria-labelledby="specialsMenuLabel" aria-hidden="true">
+        <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="specialsMenuLabel">Specials Menu</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body text-center">
+                    <p>Specials menu coming soon.</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- allow bar and specials menus to open in-page
- add carousel-based modals for each menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a1ee5c6e88326b0ac2e5c32ab0db9