### PR TITLE
Fix menu image cropping and clickable cards

### DIFF
--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -48,9 +48,9 @@
 }
 
 .menu-card img {
-  max-height: 200px;
   width: 100%;
-  object-fit: cover;
+  height: auto;
+  object-fit: contain;
 }
 
 /* Events section styling – white background with card design */
@@ -259,6 +259,6 @@ footer a:hover {
 
 @media (max-width: 575.98px) {
   .menu-card img {
-    height: 160px;
+    max-height: 160px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -88,31 +88,34 @@
             <div class="row g-4">
                 <div class="col-md-4">
                     <div class="menu-card h-100">
-                        <img src="assets/images/food-placeholder.png" class="card-img-top" alt="Delicious dishes">
+                        <a href="#" data-bs-toggle="modal" data-bs-target="#foodMenuModal">
+                            <img src="assets/images/food-placeholder.png" class="card-img-top" alt="Delicious dishes">
+                        </a>
                         <div class="p-3">
                             <h5 class="mb-2">Food Menu</h5>
                             <p class="small">A selection of starters, mains and desserts inspired by Brazilian cuisine.</p>
-                            <a href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#foodMenuModal">View Menu</a>
                         </div>
                     </div>
                 </div>
                 <div class="col-md-4">
                     <div class="menu-card h-100">
-                        <img src="assets/images/drinks-placeholder.png" class="card-img-top" alt="Signature drinks">
+                        <a href="#" data-bs-toggle="modal" data-bs-target="#barMenuModal">
+                            <img src="assets/images/drinks-placeholder.png" class="card-img-top" alt="Signature drinks">
+                        </a>
                         <div class="p-3">
                             <h5 class="mb-2">Bar Menu</h5>
                             <p class="small">Signature cocktails, fine wines and craft beers.</p>
-                            <a href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#barMenuModal">View Menu</a>
                         </div>
                     </div>
                 </div>
                 <div class="col-md-4">
                     <div class="menu-card h-100">
-                        <img src="assets/images/specials-placeholder.png" class="card-img-top" alt="Chef's specials">
+                        <a href="#" data-bs-toggle="modal" data-bs-target="#specialsMenuModal">
+                            <img src="assets/images/specials-placeholder.png" class="card-img-top" alt="Chef's specials">
+                        </a>
                         <div class="p-3">
                             <h5 class="mb-2">Specials</h5>
                             <p class="small">Seasonal dishes and chef's creations.</p>
-                            <a href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#specialsMenuModal">View Menu</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- prevent menu thumbnails from cropping by using `object-fit: contain`
- adjust responsive max-height for menu images
- remove View Menu buttons and make the menu images open the modals

## Testing
- `tidy -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_688a44a746188326b9fca1b811e62f0c