### PR TITLE
Scale menu images to uniform height

### DIFF
--- a/assets/js/uniform-menu-heights.js
+++ b/assets/js/uniform-menu-heights.js
@@ -1,0 +1,33 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const images = Array.from(document.querySelectorAll('.menus-section .menu-card img'));
+  if (images.length === 0) return;
+
+  let loaded = 0;
+  let minHeight = Infinity;
+
+  function checkDone() {
+    if (loaded !== images.length) return;
+    if (!isFinite(minHeight)) return;
+    images.forEach(img => {
+      img.style.height = `${minHeight}px`;
+      img.style.objectFit = 'contain';
+    });
+  }
+
+  images.forEach(img => {
+    const applyHeight = () => {
+      if (img.naturalHeight > 0) {
+        minHeight = Math.min(minHeight, img.naturalHeight);
+      }
+      loaded++;
+      checkDone();
+    };
+
+    if (img.complete) {
+      applyHeight();
+    } else {
+      img.addEventListener('load', applyHeight);
+      img.addEventListener('error', applyHeight);
+    }
+  });
+});

--- a/index.html
+++ b/index.html
@@ -358,6 +358,7 @@
     </script>
 
     <script src="assets/js/header.js"></script>
+    <script src="assets/js/uniform-menu-heights.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a script to set the menu card images to the smallest image height
- load the new script in the homepage

## Testing
- `python3 -m py_compile scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688a460da62883268d08edd7e97e44cc