### PR TITLE
Fix menu card height scaling

### DIFF
--- a/assets/js/uniform-menu-heights.js
+++ b/assets/js/uniform-menu-heights.js
@@ -16,8 +16,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
   images.forEach(img => {
     const applyHeight = () => {
-      if (img.naturalHeight > 0) {
-        minHeight = Math.min(minHeight, img.naturalHeight);
+      // Use the rendered height after layout so all cards scale
+      // relative to their displayed size rather than the image's
+      // intrinsic dimensions. Fallback to naturalHeight if the
+      // element isn't rendered yet.
+      const rendered = img.clientHeight || img.naturalHeight;
+      if (rendered > 0) {
+        minHeight = Math.min(minHeight, rendered);
       }
       loaded++;
       checkDone();


### PR DESCRIPTION
## Summary
- measure displayed image height instead of intrinsic height

## Testing
- `node --check assets/js/uniform-menu-heights.js`
- `python3 scripts/generate_events_json.py > /tmp/events.json`

------
https://chatgpt.com/codex/tasks/task_e_688a48ec2b788326acb6a5a226cf2df0