### PR TITLE
feat: Optimize asset loading for performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,7 @@
     <section class="hero-section d-flex align-items-center text-center position-relative">
         <!-- Video background playing behind the call‑to‑action. Muted and looped for a seamless effect. -->
         <video class="hero-video" autoplay muted loop playsinline poster="assets/images/hero.jpg">
-            <source src="assets/videos/hero-video.webm" type="video/webm">
-            <source src="assets/videos/hero.mp4" type="video/mp4">
+            <source src="assets/videos/hero-small.webm" type="video/webm">
         </video>
         <!-- Semi‑transparent overlay to improve text contrast -->
         <div class="hero-overlay"></div>
@@ -139,31 +138,31 @@
                                 <img loading="lazy" src="assets/menus/food-menu-pg1.jpg" class="d-block w-100" alt="Food Menu page 1">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/food-menu-pg2.jpg" class="d-block w-100" alt="Food Menu page 2">
+                                <img loading="lazy" data-src="assets/menus/food-menu-pg2.jpg" class="d-block w-100" alt="Food Menu page 2">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/food-menu-pg3.jpg" class="d-block w-100" alt="Food Menu page 3">
+                                <img loading="lazy" data-src="assets/menus/food-menu-pg3.jpg" class="d-block w-100" alt="Food Menu page 3">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/food-menu-pg4.jpg" class="d-block w-100" alt="Food Menu page 4">
+                                <img loading="lazy" data-src="assets/menus/food-menu-pg4.jpg" class="d-block w-100" alt="Food Menu page 4">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/food-menu-pg5.jpg" class="d-block w-100" alt="Food Menu page 5">
+                                <img loading="lazy" data-src="assets/menus/food-menu-pg5.jpg" class="d-block w-100" alt="Food Menu page 5">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/food-menu-pg6.jpg" class="d-block w-100" alt="Food Menu page 6">
+                                <img loading="lazy" data-src="assets/menus/food-menu-pg6.jpg" class="d-block w-100" alt="Food Menu page 6">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/food-menu-pg7.jpg" class="d-block w-100" alt="Food Menu page 7">
+                                <img loading="lazy" data-src="assets/menus/food-menu-pg7.jpg" class="d-block w-100" alt="Food Menu page 7">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/food-menu-pg8.jpg" class="d-block w-100" alt="Food Menu page 8">
+                                <img loading="lazy" data-src="assets/menus/food-menu-pg8.jpg" class="d-block w-100" alt="Food Menu page 8">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/food-menu-pg9.jpg" class="d-block w-100" alt="Food Menu page 9">
+                                <img loading="lazy" data-src="assets/menus/food-menu-pg9.jpg" class="d-block w-100" alt="Food Menu page 9">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/food-menu-pg10.jpg" class="d-block w-100" alt="Food Menu page 10">
+                                <img loading="lazy" data-src="assets/menus/food-menu-pg10.jpg" class="d-block w-100" alt="Food Menu page 10">
                             </div>
                         </div>
                         <button class="carousel-control-prev" type="button" data-bs-target="#foodMenuCarousel" data-bs-slide="prev">
@@ -195,43 +194,43 @@
                                 <img loading="lazy" src="assets/menus/bar-menu-pg1.jpg" class="d-block w-100" alt="Bar Menu page 1">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/bar-menu-pg2.jpg" class="d-block w-100" alt="Bar Menu page 2">
+                                <img loading="lazy" data-src="assets/menus/bar-menu-pg2.jpg" class="d-block w-100" alt="Bar Menu page 2">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/bar-menu-pg3.jpg" class="d-block w-100" alt="Bar Menu page 3">
+                                <img loading="lazy" data-src="assets/menus/bar-menu-pg3.jpg" class="d-block w-100" alt="Bar Menu page 3">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/bar-menu-pg4.jpg" class="d-block w-100" alt="Bar Menu page 4">
+                                <img loading="lazy" data-src="assets/menus/bar-menu-pg4.jpg" class="d-block w-100" alt="Bar Menu page 4">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/bar-menu-pg5.jpg" class="d-block w-100" alt="Bar Menu page 5">
+                                <img loading="lazy" data-src="assets/menus/bar-menu-pg5.jpg" class="d-block w-100" alt="Bar Menu page 5">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/bar-menu-pg6.jpg" class="d-block w-100" alt="Bar Menu page 6">
+                                <img loading="lazy" data-src="assets/menus/bar-menu-pg6.jpg" class="d-block w-100" alt="Bar Menu page 6">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/bar-menu-pg7.jpg" class="d-block w-100" alt="Bar Menu page 7">
+                                <img loading="lazy" data-src="assets/menus/bar-menu-pg7.jpg" class="d-block w-100" alt="Bar Menu page 7">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/bar-menu-pg8.jpg" class="d-block w-100" alt="Bar Menu page 8">
+                                <img loading="lazy" data-src="assets/menus/bar-menu-pg8.jpg" class="d-block w-100" alt="Bar Menu page 8">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/bar-menu-pg9.jpg" class="d-block w-100" alt="Bar Menu page 9">
+                                <img loading="lazy" data-src="assets/menus/bar-menu-pg9.jpg" class="d-block w-100" alt="Bar Menu page 9">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/bar-menu-pg10.jpg" class="d-block w-100" alt="Bar Menu page 10">
+                                <img loading="lazy" data-src="assets/menus/bar-menu-pg10.jpg" class="d-block w-100" alt="Bar Menu page 10">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/bar-menu-pg11.jpg" class="d-block w-100" alt="Bar Menu page 11">
+                                <img loading="lazy" data-src="assets/menus/bar-menu-pg11.jpg" class="d-block w-100" alt="Bar Menu page 11">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/bar-menu-pg12.jpg" class="d-block w-100" alt="Bar Menu page 12">
+                                <img loading="lazy" data-src="assets/menus/bar-menu-pg12.jpg" class="d-block w-100" alt="Bar Menu page 12">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/bar-menu-pg13.jpg" class="d-block w-100" alt="Bar Menu page 13">
+                                <img loading="lazy" data-src="assets/menus/bar-menu-pg13.jpg" class="d-block w-100" alt="Bar Menu page 13">
                             </div>
                             <div class="carousel-item">
-                                <img loading="lazy" src="assets/menus/bar-menu-pg14.jpg" class="d-block w-100" alt="Bar Menu page 14">
+                                <img loading="lazy" data-src="assets/menus/bar-menu-pg14.jpg" class="d-block w-100" alt="Bar Menu page 14">
                             </div>
                         </div>
                         <button class="carousel-control-prev" type="button" data-bs-target="#barMenuCarousel" data-bs-slide="prev">
@@ -376,5 +375,28 @@
     <script src="assets/js/header.js" defer></script>
     <script src="assets/js/uniform-menu-heights.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <!-- Lazy-load carousel images -->
+    <script>
+        document.addEventListener('DOMContentLoaded', function () {
+            function lazyLoadCarousel(carouselId) {
+                const carousel = document.getElementById(carouselId);
+                if (!carousel) return;
+
+                const onSlide = (event) => {
+                    const slide = event.relatedTarget;
+                    const img = slide.querySelector('img[data-src]');
+                    if (img) {
+                        img.src = img.dataset.src;
+                        img.removeAttribute('data-src');
+                    }
+                };
+
+                carousel.addEventListener('slide.bs.carousel', onSlide);
+            }
+
+            lazyLoadCarousel('foodMenuCarousel');
+            lazyLoadCarousel('barMenuCarousel');
+        });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
This commit introduces two significant performance improvements:

1.  **Optimized Hero Video:** The large hero video files (`hero.mp4` and `hero-video.webm`) have been replaced with a much smaller, optimized version (`hero-small.webm`). This dramatically reduces the initial page load time.

2.  **Lazy-Loaded Menu Images:** The menu carousels in the modals now lazy-load their images. Images are only fetched from the server as the user navigates to them, rather than all at once on page load. This significantly reduces the initial data download size.