### PR TITLE
Fix delete merged branches workflow

### DIFF
--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Delete merged branches
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DEFAULT_BRANCH: ${{ github.repository_default_branch }}
         run: |
           git config --global user.name "github-actions"
           git config --global user.email "github-actions@github.com"


### PR DESCRIPTION
## Summary
- fix the `delete-merged-branches.yml` workflow to reference the repository's
  default branch reliably

## Testing
- `python scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688b2c54c8cc83269234d7987e1e6cf1