### PR TITLE
Add contact section with map

### DIFF
--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -78,6 +78,25 @@ h1, h2, h3, .brand-name { font-family: 'Fraunces', serif; }
   object-fit: contain;
 }
 
+/* Contact section styling */
+.contact-section {
+  background-color: #f7f8fc;
+  color: #1a1a1a;
+}
+
+.contact-section h2 {
+  color: #005aab;
+}
+
+.contact-info a {
+  color: #005aab;
+  text-decoration: none;
+}
+
+.contact-info a:hover {
+  text-decoration: underline;
+}
+
 
 /* Announcement bar uses the primary colour */
 .announcement-bar {

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
                     <li class="nav-item"><a class="nav-link" href="#events">Upcoming Events</a></li>
                     <li class="nav-item"><a class="nav-link" href="#" data-bs-toggle="modal" data-bs-target="#reservationsModal">Reservations</a></li>
                     <li class="nav-item"><a class="nav-link" href="#" data-bs-toggle="modal" data-bs-target="#partyBookingModal">Party Bookings</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#contact">Find Us</a></li>
                 </ul>
             </div>
         </div>
@@ -299,6 +300,28 @@
         </div>
     </section>
 
+    <!-- Contact Section -->
+    <section id="contact" class="py-5 contact-section">
+        <div class="container">
+            <h2 class="text-center mb-4">Find Us</h2>
+            <div class="row g-4 align-items-center">
+                <div class="col-md-6 contact-info">
+                    <p><strong>Address:</strong><br>
+                        10, Sri Krishna Temple Rd,<br>
+                        100 Feet Rd, Indiranagar,<br>
+                        Bengaluru, Karnataka 560038
+                    </p>
+                    <p><strong>Phone:</strong> <a href="tel:+918105753990">+91 81057 53990</a></p>
+                </div>
+                <div class="col-md-6">
+                    <div class="ratio ratio-4x3">
+                        <iframe loading="lazy" style="border:0" allowfullscreen
+                            src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3890.8866!2d77.640056!3d12.970923!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3bae17a47c27bc57%3A0x620ba442b1721b1c!2sBoteco%20-%20Restaurante%20Brasileiro!5e0!3m2!1sen!2sin!4v1688243088052!5m2!1sen!2sin"></iframe>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
 
     <!-- Load events dynamically from the GitHub events directory -->
     <script>


### PR DESCRIPTION
## Summary
- add contact nav link
- add contact section with address, phone number, and Google Map
- style contact section

## Testing
- `python3 -m py_compile scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688b31a1b5d88326885576db0974630e