### PR TITLE
Update Find Us link

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
                     <li class="nav-item"><a class="nav-link" href="#events">Upcoming Events</a></li>
                     <li class="nav-item"><a class="nav-link" href="#" data-bs-toggle="modal" data-bs-target="#reservationsModal">Reservations</a></li>
                     <li class="nav-item"><a class="nav-link" href="#" data-bs-toggle="modal" data-bs-target="#partyBookingModal">Party Bookings</a></li>
-                    <li class="nav-item"><a class="nav-link" href="#contact">Find Us</a></li>
+                    <li class="nav-item"><a class="nav-link" href="https://share.google/NrnkosMvBCGq9GTIY" target="_blank" rel="noopener noreferrer">Find Us</a></li>
                 </ul>
             </div>
         </div>
@@ -307,16 +307,16 @@
             <div class="row g-4 align-items-center">
                 <div class="col-md-6 contact-info">
                     <p><strong>Address:</strong><br>
-                        10, Sri Krishna Temple Rd,<br>
-                        100 Feet Rd, Indiranagar,<br>
-                        Bengaluru, Karnataka 560038
+                        16/3, Magrath Road,<br>
+                        Ashok Nagar, Bengaluru,<br>
+                        Karnataka 560025
                     </p>
                     <p><strong>Phone:</strong> <a href="tel:+918105753990">+91 81057 53990</a></p>
                 </div>
                 <div class="col-md-6">
                     <div class="ratio ratio-4x3">
                         <iframe loading="lazy" style="border:0" allowfullscreen
-                            src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3890.8866!2d77.640056!3d12.970923!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3bae17a47c27bc57%3A0x620ba442b1721b1c!2sBoteco%20-%20Restaurante%20Brasileiro!5e0!3m2!1sen!2sin!4v1688243088052!5m2!1sen!2sin"></iframe>
+                            src="https://www.google.com/maps/embed?origin=mfe&pb=!1m2!2m1!1s12.970488,77.610534"></iframe>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- update the navbar link for **Find Us** to use the Google share link
- refresh address and map info in the contact section

## Testing
- `python3 -m py_compile scripts/generate_events_json.py`


------
https://chatgpt.com/codex/tasks/task_e_688b35d4f3d4832692c9351ac09a290f