### PR TITLE
Add optional local font folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ displays images stored in `assets/menus/` following the naming pattern
 these images automatically, so simply add or remove files and they will appear
 in their respective galleries.
 
+## Custom Fonts
+
+Place your own font files in `assets/fonts/` using the filenames
+`boteco-font.woff2` or `boteco-font.woff`. The stylesheet will try to
+load these files first. If the directory is empty the site falls back to
+the Fraunces typeface served from Google Fonts.
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -14,8 +14,20 @@
  * Accent 2 (teal):      #54c5d0
  * Accent 3 (green):     #a2d06e
  */
-body { font-family: 'Fraunces', serif; }
-h1, h2, h3, .brand-name { font-family: 'Fraunces', serif; }
+/* Try to load a custom font from assets/fonts/ first.  If the files
+ * `boteco-font.woff2` or `boteco-font.woff` are not present the rule
+ * is ignored and the site falls back to the Fraunces web font. */
+@font-face {
+  font-family: 'BotecoFont';
+  src: url('../fonts/boteco-font.woff2') format('woff2'),
+       url('../fonts/boteco-font.woff') format('woff');
+  font-weight: normal;
+  font-style: normal;
+  font-display: swap;
+}
+
+body { font-family: 'BotecoFont', 'Fraunces', serif; }
+h1, h2, h3, .brand-name { font-family: 'BotecoFont', 'Fraunces', serif; }
 
 
 


### PR DESCRIPTION
## Summary
- add `assets/fonts` directory to host custom fonts
- load `BotecoFont` from `assets/fonts` with `@font-face`
- fall back to Fraunces when local font files are missing
- document custom font usage in README

## Testing
- `python3 -m py_compile scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688b3596e4c08326b6389ab73ad5528f