### PR TITLE
Improve menu gallery navigation

### DIFF
--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -297,3 +297,36 @@ footer a:hover {
     max-height: 160px;
   }
 }
+
+/* Menu gallery styles */
+.menu-gallery .menu-image {
+  max-height: 80vh;
+  width: 100%;
+  object-fit: contain;
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
+}
+
+.menu-gallery .prev-btn,
+.menu-gallery .next-btn {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  font-size: 1.25rem;
+  padding: 0;
+  opacity: 0.85;
+}
+
+.menu-gallery .prev-btn:hover,
+.menu-gallery .next-btn:hover {
+  opacity: 1;
+}
+
+.menu-gallery .image-counter {
+  background-color: rgba(255, 255, 255, 0.7);
+  color: #005aab;
+  font-weight: 600;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-size: 0.9rem;
+}

--- a/assets/js/menu-gallery.js
+++ b/assets/js/menu-gallery.js
@@ -28,12 +28,29 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
+    const cache = images.map(src => {
+      const img = new Image();
+      img.src = src;
+      return img;
+    });
+
     let index = 0;
     const update = () => {
-      imgEl.src = images[index];
-      counterEl.textContent = `${index + 1} / ${images.length}`;
-      prevBtn.disabled = index === 0;
-      nextBtn.disabled = index === images.length - 1;
+      const cached = cache[index];
+      const show = () => {
+        imgEl.src = cached.src;
+        counterEl.textContent = `${index + 1} / ${images.length}`;
+        prevBtn.disabled = index === 0;
+        nextBtn.disabled = index === images.length - 1;
+        requestAnimationFrame(() => { imgEl.style.opacity = 1; });
+      };
+
+      imgEl.style.opacity = 0;
+      if (cached.complete) {
+        show();
+      } else {
+        cached.addEventListener('load', show, { once: true });
+      }
     };
 
     prevBtn.addEventListener('click', () => {

--- a/bar-menu.html
+++ b/bar-menu.html
@@ -36,7 +36,7 @@
     <main class="py-5 mt-5">
         <div class="container">
             <h1 class="text-center mb-4">Bar Menu</h1>
-            <div id="barMenuGallery" data-menu-gallery="bar-menu" class="mb-4 text-center">
+            <div id="barMenuGallery" data-menu-gallery="bar-menu" class="menu-gallery mb-4 text-center">
                 <div class="position-relative d-inline-block">
                     <button class="prev-btn btn btn-primary position-absolute top-50 start-0 translate-middle-y" style="z-index:2">
                         <i class="fa-solid fa-chevron-left"></i>
@@ -45,8 +45,8 @@
                     <button class="next-btn btn btn-primary position-absolute top-50 end-0 translate-middle-y" style="z-index:2">
                         <i class="fa-solid fa-chevron-right"></i>
                     </button>
+                    <div class="image-counter position-absolute bottom-0 end-0 m-2"></div>
                 </div>
-                <div class="image-counter mt-2"></div>
             </div>
         </div>
     </main>

--- a/food-menu.html
+++ b/food-menu.html
@@ -36,7 +36,7 @@
     <main class="py-5 mt-5">
         <div class="container">
             <h1 class="text-center mb-4">Food Menu</h1>
-            <div id="foodMenuGallery" data-menu-gallery="food-menu" class="mb-4 text-center">
+            <div id="foodMenuGallery" data-menu-gallery="food-menu" class="menu-gallery mb-4 text-center">
                 <div class="position-relative d-inline-block">
                     <button class="prev-btn btn btn-primary position-absolute top-50 start-0 translate-middle-y" style="z-index:2">
                         <i class="fa-solid fa-chevron-left"></i>
@@ -45,8 +45,8 @@
                     <button class="next-btn btn btn-primary position-absolute top-50 end-0 translate-middle-y" style="z-index:2">
                         <i class="fa-solid fa-chevron-right"></i>
                     </button>
+                    <div class="image-counter position-absolute bottom-0 end-0 m-2"></div>
                 </div>
-                <div class="image-counter mt-2"></div>
             </div>
         </div>
     </main>

--- a/specials-menu.html
+++ b/specials-menu.html
@@ -36,7 +36,7 @@
     <main class="py-5 mt-5">
         <div class="container">
             <h1 class="text-center mb-4">Specials Menu</h1>
-            <div id="specialsMenuGallery" data-menu-gallery="specials-menu" class="mb-4 text-center">
+            <div id="specialsMenuGallery" data-menu-gallery="specials-menu" class="menu-gallery mb-4 text-center">
                 <div class="position-relative d-inline-block">
                     <button class="prev-btn btn btn-primary position-absolute top-50 start-0 translate-middle-y" style="z-index:2">
                         <i class="fa-solid fa-chevron-left"></i>
@@ -45,8 +45,8 @@
                     <button class="next-btn btn btn-primary position-absolute top-50 end-0 translate-middle-y" style="z-index:2">
                         <i class="fa-solid fa-chevron-right"></i>
                     </button>
+                    <div class="image-counter position-absolute bottom-0 end-0 m-2"></div>
                 </div>
-                <div class="image-counter mt-2"></div>
             </div>
         </div>
     </main>


### PR DESCRIPTION
## Summary
- preload menu images and fade between them
- highlight menu navigation arrows and counter
- overlay page counter in the menu gallery

## Testing
- `python3 -m py_compile scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688b43e0483c83268000253ecf3dc46a