### PR TITLE
Fix header link to Find Us section

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
                     <li class="nav-item"><a class="nav-link" href="#events">Upcoming Events</a></li>
                     <li class="nav-item"><a class="nav-link" href="#" data-bs-toggle="modal" data-bs-target="#reservationsModal">Reservations</a></li>
                     <li class="nav-item"><a class="nav-link" href="#" data-bs-toggle="modal" data-bs-target="#partyBookingModal">Party Bookings</a></li>
-                    <li class="nav-item"><a class="nav-link" href="https://www.google.com/maps/place/Boteco+-+Restaurante+Brasileiro/@12.9704157,77.6104685,17z" target="_blank" rel="noopener noreferrer">Find Us</a></li>
+                    <li class="nav-item"><a class="nav-link" href="#contact">Find Us</a></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- correct Find Us link in the main navigation so it jumps to the contact section

## Testing
- `python3 scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688b452dda6c8326b3434c33c5f7f3d8