### PR TITLE
Move menu navigation arrows next to headings

### DIFF
--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -330,3 +330,7 @@ footer a:hover {
   border-radius: 0.25rem;
   font-size: 0.9rem;
 }
+
+.menu-gallery .menu-title {
+  font-size: 2rem;
+}

--- a/assets/js/menu-gallery.js
+++ b/assets/js/menu-gallery.js
@@ -67,6 +67,28 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
 
+    let touchStartX = null;
+    wrapper.addEventListener('touchstart', (e) => {
+      if (e.touches.length === 1) {
+        touchStartX = e.touches[0].clientX;
+      }
+    });
+
+    wrapper.addEventListener('touchend', (e) => {
+      if (touchStartX === null || e.changedTouches.length !== 1) return;
+      const diff = e.changedTouches[0].clientX - touchStartX;
+      touchStartX = null;
+      if (Math.abs(diff) > 50) {
+        if (diff < 0 && index < images.length - 1) {
+          index++;
+          update();
+        } else if (diff > 0 && index > 0) {
+          index--;
+          update();
+        }
+      }
+    });
+
     update();
   });
 });

--- a/bar-menu.html
+++ b/bar-menu.html
@@ -35,16 +35,18 @@
     </nav>
     <main class="py-5 mt-5">
         <div class="container">
-            <h1 class="text-center mb-4">Bar Menu</h1>
             <div id="barMenuGallery" data-menu-gallery="bar-menu" class="menu-gallery mb-4 text-center">
-                <div class="position-relative d-inline-block">
-                    <button class="prev-btn btn btn-primary position-absolute top-50 start-0 translate-middle-y" style="z-index:2">
+                <div class="d-flex justify-content-center align-items-center mb-3">
+                    <button class="prev-btn btn btn-primary me-3">
                         <i class="fa-solid fa-chevron-left"></i>
                     </button>
-                    <img loading="lazy" class="menu-image img-fluid" src="" alt="Bar Menu">
-                    <button class="next-btn btn btn-primary position-absolute top-50 end-0 translate-middle-y" style="z-index:2">
+                    <h1 class="menu-title mb-0">Bar Menu</h1>
+                    <button class="next-btn btn btn-primary ms-3">
                         <i class="fa-solid fa-chevron-right"></i>
                     </button>
+                </div>
+                <div class="position-relative d-inline-block">
+                    <img loading="lazy" class="menu-image img-fluid" src="" alt="Bar Menu">
                     <div class="image-counter position-absolute bottom-0 end-0 m-2"></div>
                 </div>
             </div>

--- a/food-menu.html
+++ b/food-menu.html
@@ -35,16 +35,18 @@
     </nav>
     <main class="py-5 mt-5">
         <div class="container">
-            <h1 class="text-center mb-4">Food Menu</h1>
             <div id="foodMenuGallery" data-menu-gallery="food-menu" class="menu-gallery mb-4 text-center">
-                <div class="position-relative d-inline-block">
-                    <button class="prev-btn btn btn-primary position-absolute top-50 start-0 translate-middle-y" style="z-index:2">
+                <div class="d-flex justify-content-center align-items-center mb-3">
+                    <button class="prev-btn btn btn-primary me-3">
                         <i class="fa-solid fa-chevron-left"></i>
                     </button>
-                    <img loading="lazy" class="menu-image img-fluid" src="" alt="Food Menu">
-                    <button class="next-btn btn btn-primary position-absolute top-50 end-0 translate-middle-y" style="z-index:2">
+                    <h1 class="menu-title mb-0">Food Menu</h1>
+                    <button class="next-btn btn btn-primary ms-3">
                         <i class="fa-solid fa-chevron-right"></i>
                     </button>
+                </div>
+                <div class="position-relative d-inline-block">
+                    <img loading="lazy" class="menu-image img-fluid" src="" alt="Food Menu">
                     <div class="image-counter position-absolute bottom-0 end-0 m-2"></div>
                 </div>
             </div>

--- a/specials-menu.html
+++ b/specials-menu.html
@@ -35,16 +35,18 @@
     </nav>
     <main class="py-5 mt-5">
         <div class="container">
-            <h1 class="text-center mb-4">Specials Menu</h1>
             <div id="specialsMenuGallery" data-menu-gallery="specials-menu" class="menu-gallery mb-4 text-center">
-                <div class="position-relative d-inline-block">
-                    <button class="prev-btn btn btn-primary position-absolute top-50 start-0 translate-middle-y" style="z-index:2">
+                <div class="d-flex justify-content-center align-items-center mb-3">
+                    <button class="prev-btn btn btn-primary me-3">
                         <i class="fa-solid fa-chevron-left"></i>
                     </button>
-                    <img loading="lazy" class="menu-image img-fluid" src="" alt="Specials Menu">
-                    <button class="next-btn btn btn-primary position-absolute top-50 end-0 translate-middle-y" style="z-index:2">
+                    <h1 class="menu-title mb-0">Specials Menu</h1>
+                    <button class="next-btn btn btn-primary ms-3">
                         <i class="fa-solid fa-chevron-right"></i>
                     </button>
+                </div>
+                <div class="position-relative d-inline-block">
+                    <img loading="lazy" class="menu-image img-fluid" src="" alt="Specials Menu">
                     <div class="image-counter position-absolute bottom-0 end-0 m-2"></div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- reposition menu navigation arrows next to the page titles
- add swipe navigation support on touch devices
- tweak styles for menu headings

## Testing
- `python3 -m py_compile scripts/generate_events_json.py`


------
https://chatgpt.com/codex/tasks/task_e_688b46189cd48326af4f6d47cea95932