### PR TITLE
Add visible page counter beside menu titles

### DIFF
--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -323,12 +323,10 @@ footer a:hover {
 }
 
 .menu-gallery .image-counter {
-  background-color: rgba(255, 255, 255, 0.7);
-  color: #005aab;
+  color: #000;
   font-weight: 600;
-  padding: 0.25rem 0.5rem;
-  border-radius: 0.25rem;
-  font-size: 0.9rem;
+  font-size: 1rem;
+  margin: 0 0.5rem;
 }
 
 .menu-gallery .menu-title {

--- a/bar-menu.html
+++ b/bar-menu.html
@@ -37,17 +37,17 @@
         <div class="container">
             <div id="barMenuGallery" data-menu-gallery="bar-menu" class="menu-gallery mb-4 text-center">
                 <div class="d-flex justify-content-center align-items-center mb-3">
-                    <button class="prev-btn btn btn-primary me-3">
+                    <button class="prev-btn btn btn-outline-dark me-3">
                         <i class="fa-solid fa-chevron-left"></i>
                     </button>
                     <h1 class="menu-title mb-0">Bar Menu</h1>
-                    <button class="next-btn btn btn-primary ms-3">
+                    <div class="image-counter"></div>
+                    <button class="next-btn btn btn-outline-dark ms-3">
                         <i class="fa-solid fa-chevron-right"></i>
                     </button>
                 </div>
                 <div class="position-relative d-inline-block">
                     <img loading="lazy" class="menu-image img-fluid" src="" alt="Bar Menu">
-                    <div class="image-counter position-absolute bottom-0 end-0 m-2"></div>
                 </div>
             </div>
         </div>

--- a/food-menu.html
+++ b/food-menu.html
@@ -37,17 +37,17 @@
         <div class="container">
             <div id="foodMenuGallery" data-menu-gallery="food-menu" class="menu-gallery mb-4 text-center">
                 <div class="d-flex justify-content-center align-items-center mb-3">
-                    <button class="prev-btn btn btn-primary me-3">
+                    <button class="prev-btn btn btn-outline-dark me-3">
                         <i class="fa-solid fa-chevron-left"></i>
                     </button>
                     <h1 class="menu-title mb-0">Food Menu</h1>
-                    <button class="next-btn btn btn-primary ms-3">
+                    <div class="image-counter"></div>
+                    <button class="next-btn btn btn-outline-dark ms-3">
                         <i class="fa-solid fa-chevron-right"></i>
                     </button>
                 </div>
                 <div class="position-relative d-inline-block">
                     <img loading="lazy" class="menu-image img-fluid" src="" alt="Food Menu">
-                    <div class="image-counter position-absolute bottom-0 end-0 m-2"></div>
                 </div>
             </div>
         </div>

--- a/specials-menu.html
+++ b/specials-menu.html
@@ -37,17 +37,17 @@
         <div class="container">
             <div id="specialsMenuGallery" data-menu-gallery="specials-menu" class="menu-gallery mb-4 text-center">
                 <div class="d-flex justify-content-center align-items-center mb-3">
-                    <button class="prev-btn btn btn-primary me-3">
+                    <button class="prev-btn btn btn-outline-dark me-3">
                         <i class="fa-solid fa-chevron-left"></i>
                     </button>
                     <h1 class="menu-title mb-0">Specials Menu</h1>
-                    <button class="next-btn btn btn-primary ms-3">
+                    <div class="image-counter"></div>
+                    <button class="next-btn btn btn-outline-dark ms-3">
                         <i class="fa-solid fa-chevron-right"></i>
                     </button>
                 </div>
                 <div class="position-relative d-inline-block">
                     <img loading="lazy" class="menu-image img-fluid" src="" alt="Specials Menu">
-                    <div class="image-counter position-absolute bottom-0 end-0 m-2"></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- move gallery page counter into header area beside the menu titles
- style the counter in black
- switch menu arrows to `btn-outline-dark`

## Testing
- `tidy -qe bar-menu.html`
- `tidy -qe food-menu.html`
- `tidy -qe specials-menu.html`


------
https://chatgpt.com/codex/tasks/task_e_688b4a322d908326b86b9b0b6c945fdb