### PR TITLE
Update mobile navbar dropdown color

### DIFF
--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -170,6 +170,15 @@ h1, h2, h3, .brand-name { font-family: 'BotecoFont', 'Fraunces', serif; }
   display: none;
 }
 
+/* Mobile navbar toggler – match icon colour with the logo */
+.navbar-dark .navbar-toggler {
+  border-color: #005aab;
+}
+
+.navbar-dark .navbar-toggler-icon {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='%23005aab' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
 /* Section styling for dark areas */
 /* Section styling – lighten backgrounds for a more airy look while
    retaining accent colours for headings. */


### PR DESCRIPTION
## Summary
- customize the navbar toggler so its icon uses the site's blue

## Testing
- `python3 -m py_compile scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688b4acf31208326b0df164e234dd631