### PR TITLE
Add carousel counters for menu modals

### DIFF
--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -341,3 +341,26 @@ footer a:hover {
 .menu-gallery .menu-title {
   font-size: 2rem;
 }
+
+/* Modal carousel toolbar styles */
+.modal .prev-btn,
+.modal .next-btn {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  font-size: 1.25rem;
+  padding: 0;
+  opacity: 0.85;
+}
+
+.modal .prev-btn:hover,
+.modal .next-btn:hover {
+  opacity: 1;
+}
+
+.modal .image-counter {
+  color: #000;
+  font-weight: 600;
+  font-size: 1rem;
+  margin: 0 0.5rem;
+}

--- a/assets/js/carousel-counter.js
+++ b/assets/js/carousel-counter.js
@@ -1,0 +1,29 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const carousels = document.querySelectorAll('.modal .carousel');
+  carousels.forEach(carouselEl => {
+    const instance = bootstrap.Carousel.getOrCreateInstance(carouselEl);
+    const items = carouselEl.querySelectorAll('.carousel-item');
+    const total = items.length;
+    const modal = carouselEl.closest('.modal');
+    const counterEl = modal.querySelector('.image-counter');
+    const prevBtn = modal.querySelector('.prev-btn');
+    const nextBtn = modal.querySelector('.next-btn');
+
+    function update(index) {
+      if (counterEl) {
+        counterEl.textContent = `${index + 1} / ${total}`;
+      }
+    }
+
+    const active = Array.from(items).indexOf(carouselEl.querySelector('.carousel-item.active'));
+    update(active >= 0 ? active : 0);
+
+    carouselEl.addEventListener('slid.bs.carousel', e => {
+      const idx = typeof e.to === 'number' ? e.to : Array.from(items).indexOf(carouselEl.querySelector('.carousel-item.active'));
+      update(idx >= 0 ? idx : 0);
+    });
+
+    if (prevBtn) prevBtn.addEventListener('click', () => instance.prev());
+    if (nextBtn) nextBtn.addEventListener('click', () => instance.next());
+  });
+});

--- a/index.html
+++ b/index.html
@@ -128,6 +128,16 @@
                     <h5 class="modal-title" id="foodMenuLabel">Food Menu</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
+                <div class="d-flex justify-content-center align-items-center mb-3">
+                    <button class="prev-btn btn btn-outline-dark me-3">
+                        <i class="fa-solid fa-chevron-left"></i>
+                    </button>
+                    <h5 class="mb-0">Food Menu</h5>
+                    <div class="image-counter"></div>
+                    <button class="next-btn btn btn-outline-dark ms-3">
+                        <i class="fa-solid fa-chevron-right"></i>
+                    </button>
+                </div>
                 <div class="modal-body">
                     <div id="foodMenuCarousel" class="carousel slide" data-bs-ride="carousel">
                         <div class="carousel-inner">
@@ -162,14 +172,6 @@
                                 <img loading="lazy" src="assets/menus/food-menu-pg10.jpg" class="d-block w-100" alt="Food Menu page 10">
                             </div>
                         </div>
-                        <button class="carousel-control-prev" type="button" data-bs-target="#foodMenuCarousel" data-bs-slide="prev">
-                            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                            <span class="visually-hidden">Previous</span>
-                        </button>
-                        <button class="carousel-control-next" type="button" data-bs-target="#foodMenuCarousel" data-bs-slide="next">
-                            <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                            <span class="visually-hidden">Next</span>
-                        </button>
                     </div>
                 </div>
             </div>
@@ -183,6 +185,16 @@
                 <div class="modal-header">
                     <h5 class="modal-title" id="barMenuLabel">Bar Menu</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="d-flex justify-content-center align-items-center mb-3">
+                    <button class="prev-btn btn btn-outline-dark me-3">
+                        <i class="fa-solid fa-chevron-left"></i>
+                    </button>
+                    <h5 class="mb-0">Bar Menu</h5>
+                    <div class="image-counter"></div>
+                    <button class="next-btn btn btn-outline-dark ms-3">
+                        <i class="fa-solid fa-chevron-right"></i>
+                    </button>
                 </div>
                 <div class="modal-body">
                     <div id="barMenuCarousel" class="carousel slide" data-bs-ride="carousel">
@@ -230,14 +242,6 @@
                                 <img loading="lazy" src="assets/menus/bar-menu-pg14.jpg" class="d-block w-100" alt="Bar Menu page 14">
                             </div>
                         </div>
-                        <button class="carousel-control-prev" type="button" data-bs-target="#barMenuCarousel" data-bs-slide="prev">
-                            <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-                            <span class="visually-hidden">Previous</span>
-                        </button>
-                        <button class="carousel-control-next" type="button" data-bs-target="#barMenuCarousel" data-bs-slide="next">
-                            <span class="carousel-control-next-icon" aria-hidden="true"></span>
-                            <span class="visually-hidden">Next</span>
-                        </button>
                     </div>
                 </div>
             </div>
@@ -427,6 +431,7 @@
 
     <script src="assets/js/header.js" defer></script>
     <script src="assets/js/uniform-menu-heights.js" defer></script>
+    <script src="assets/js/carousel-counter.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add toolbar with prev/next buttons and counter to food & bar menu modals
- hide built-in carousel controls and hook new toolbar to carousel
- implement carousel-counter.js to update page numbers
- style toolbar elements in CSS
- load the new script on the homepage

## Testing
- `python3 scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688b4f0cffc48326a10de80d6e74b685