### PR TITLE
Fix header awards visibility

### DIFF
--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -366,17 +366,20 @@ footer a:hover {
 }
 
 /* Header awards */
+/* Display awards inline and slightly larger */
 .header-awards {
+  display: flex;
   gap: 0.5rem;
+  align-items: center;
 }
 
 .header-awards img {
-  height: 40px;
+  height: 60px;
   width: auto;
 }
 
 @media (max-width: 767.98px) {
   .header-awards img {
-    height: 30px;
+    height: 40px;
   }
 }

--- a/bar-menu.html
+++ b/bar-menu.html
@@ -31,7 +31,7 @@
                     </li>
                 </ul>
             </div>
-            <div id="header-awards" class="header-awards d-none d-lg-flex ms-auto"></div>
+            <div id="header-awards" class="header-awards ms-auto"></div>
         </div>
     </nav>
     <main class="py-5 mt-5">

--- a/food-menu.html
+++ b/food-menu.html
@@ -31,7 +31,7 @@
                     </li>
                 </ul>
             </div>
-            <div id="header-awards" class="header-awards d-none d-lg-flex ms-auto"></div>
+            <div id="header-awards" class="header-awards ms-auto"></div>
         </div>
     </nav>
     <main class="py-5 mt-5">

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
                     <li class="nav-item"><a class="nav-link" href="#contact">Find Us</a></li>
                 </ul>
             </div>
-            <div id="header-awards" class="header-awards d-none d-lg-flex ms-auto"></div>
+            <div id="header-awards" class="header-awards ms-auto"></div>
         </div>
     </nav>
 

--- a/party-booking.html
+++ b/party-booking.html
@@ -31,7 +31,7 @@
                     </li>
                 </ul>
             </div>
-            <div id="header-awards" class="header-awards d-none d-lg-flex ms-auto"></div>
+            <div id="header-awards" class="header-awards ms-auto"></div>
         </div>
     </nav>
     <main class="py-5 mt-5">

--- a/specials-menu.html
+++ b/specials-menu.html
@@ -31,7 +31,7 @@
                     </li>
                 </ul>
             </div>
-            <div id="header-awards" class="header-awards d-none d-lg-flex ms-auto"></div>
+            <div id="header-awards" class="header-awards ms-auto"></div>
         </div>
     </nav>
     <main class="py-5 mt-5">


### PR DESCRIPTION
## Summary
- display award badges on all screen sizes
- enlarge award badge images in the navbar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b61a346608326914d9c9a53e54794