### PR TITLE
Fix menu gallery image loading

### DIFF
--- a/assets/js/menu-gallery.js
+++ b/assets/js/menu-gallery.js
@@ -11,13 +11,14 @@ document.addEventListener('DOMContentLoaded', () => {
       const imgs = [];
       for (let i = 1; i <= 50; i++) {
         const url = `assets/menus/${menu}-pg${i}.jpg`;
-        try {
-          const res = await fetch(url, { method: 'HEAD' });
-          if (!res.ok) break;
-          imgs.push(url);
-        } catch (e) {
-          break;
-        }
+        const exists = await new Promise(res => {
+          const img = new Image();
+          img.onload = () => res(true);
+          img.onerror = () => res(false);
+          img.src = url;
+        });
+        if (!exists) break;
+        imgs.push(url);
       }
       return imgs;
     }


### PR DESCRIPTION
## Summary
- check menu images using an Image element instead of `fetch`

## Testing
- `node scripts/test-image-load.js` (images load via `file://` and `http://localhost:8080`)

------
https://chatgpt.com/codex/tasks/task_e_688b677d69c883269714afd1db5be39a