### PR TITLE
Add SEO metadata and sitemap

### DIFF
--- a/bar-menu.html
+++ b/bar-menu.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="View the bar menu for Boteco – Restaurante Brasileiro in Bengaluru.">
+    <meta property="og:title" content="Bar Menu – Boteco">
+    <meta property="og:description" content="View the bar menu for Boteco – Restaurante Brasileiro in Bengaluru.">
+    <meta property="og:image" content="assets/images/hero.jpg">
+    <link rel="canonical" href="https://boteco.co.in/bar-menu.html">
     <title>Bar Menu – Boteco</title>
     <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">

--- a/food-menu.html
+++ b/food-menu.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="View the full food menu for Boteco – Restaurante Brasileiro in Bengaluru.">
+    <meta property="og:title" content="Food Menu – Boteco">
+    <meta property="og:description" content="View the full food menu for Boteco – Restaurante Brasileiro in Bengaluru.">
+    <meta property="og:image" content="assets/images/hero.jpg">
+    <link rel="canonical" href="https://boteco.co.in/food-menu.html">
     <title>Food Menu – Boteco</title>
     <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <meta property="og:title" content="Boteco – Restaurante Brasileiro">
     <meta property="og:description" content="Boteco is a cosy Brazilian restaurant in Bengaluru serving authentic dishes, cocktails and live events.">
     <meta property="og:image" content="assets/images/hero.jpg">
+    <link rel="canonical" href="https://boteco.co.in/index.html">
     <title>Boteco – Restaurante Brasileiro</title>
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
@@ -58,6 +59,7 @@
         <!-- Semi‑transparent overlay to improve text contrast -->
         <div class="hero-overlay"></div>
         <div class="container position-relative">
+            <h1 class="text-white mb-3">Boteco – Restaurante Brasileiro</h1>
             <p class="lead text-white mb-4">Ranked among India’s top 50, by Condé Nast Traveller. We bring the true spirit of Brazil to your table.</p>
             <a href="#" data-bs-toggle="modal" data-bs-target="#reservationsModal" class="btn btn-lg btn-primary px-4">Reserve Your Table</a>
         </div>

--- a/party-booking.html
+++ b/party-booking.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Enquire about hosting a party or event at Boteco – Restaurante Brasileiro in Bengaluru.">
+    <meta property="og:title" content="Party &amp; Events – Boteco">
+    <meta property="og:description" content="Enquire about hosting a party or event at Boteco – Restaurante Brasileiro in Bengaluru.">
+    <meta property="og:image" content="assets/images/hero.jpg">
+    <link rel="canonical" href="https://boteco.co.in/party-booking.html">
     <title>Party & Events – Boteco</title>
     <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://boteco.co.in/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://boteco.co.in/index.html</loc>
+  </url>
+  <url>
+    <loc>https://boteco.co.in/bar-menu.html</loc>
+  </url>
+  <url>
+    <loc>https://boteco.co.in/food-menu.html</loc>
+  </url>
+  <url>
+    <loc>https://boteco.co.in/party-booking.html</loc>
+  </url>
+  <url>
+    <loc>https://boteco.co.in/specials-menu.html</loc>
+  </url>
+</urlset>

--- a/specials-menu.html
+++ b/specials-menu.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="View the specials menu for Boteco – Restaurante Brasileiro in Bengaluru.">
+    <meta property="og:title" content="Specials Menu – Boteco">
+    <meta property="og:description" content="View the specials menu for Boteco – Restaurante Brasileiro in Bengaluru.">
+    <meta property="og:image" content="assets/images/hero.jpg">
+    <link rel="canonical" href="https://boteco.co.in/specials-menu.html">
     <title>Specials Menu – Boteco</title>
     <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">


### PR DESCRIPTION
## Summary
- add a hero heading on the homepage
- include canonical and Open Graph metadata across pages
- provide sitemap.xml and robots.txt for search engines

## Testing
- `python3 -m py_compile scripts/generate_events_json.py`


------
https://chatgpt.com/codex/tasks/task_e_688b67a29a3c83268e640194f11b7639