### PR TITLE
Fix specials menu images on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,8 +257,30 @@
                     <h5 class="modal-title" id="specialsMenuLabel">Specials Menu</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
-                <div class="modal-body text-center">
-                    <p>Specials menu coming soon.</p>
+                <div class="d-flex justify-content-center align-items-center mb-3">
+                    <button class="prev-btn btn btn-outline-dark me-3">
+                        <i class="fa-solid fa-chevron-left"></i>
+                    </button>
+                    <h5 class="mb-0">Specials Menu</h5>
+                    <div class="image-counter"></div>
+                    <button class="next-btn btn btn-outline-dark ms-3">
+                        <i class="fa-solid fa-chevron-right"></i>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <div id="specialsMenuCarousel" class="carousel slide" data-bs-ride="carousel">
+                        <div class="carousel-inner">
+                            <div class="carousel-item active">
+                                <img loading="lazy" src="assets/menus/specials-menu-pg1.jpg" class="d-block w-100" alt="Specials Menu page 1">
+                            </div>
+                            <div class="carousel-item">
+                                <img loading="lazy" src="assets/menus/specials-menu-pg2.jpg" class="d-block w-100" alt="Specials Menu page 2">
+                            </div>
+                            <div class="carousel-item">
+                                <img loading="lazy" src="assets/menus/specials-menu-pg3.jpg" class="d-block w-100" alt="Specials Menu page 3">
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add carousel images to specials menu modal

## Testing
- `python3 -m py_compile scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688b69ff518883268acb9789b4144d16