### PR TITLE
Fix canonical URL for homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta property="og:title" content="Boteco – Restaurante Brasileiro">
     <meta property="og:description" content="Boteco is a cosy Brazilian restaurant in Bengaluru serving authentic dishes, cocktails and live events.">
     <meta property="og:image" content="assets/images/hero.jpg">
-    <link rel="canonical" href="https://boteco.co.in/index.html">
+    <link rel="canonical" href="https://boteco.co.in/">
     <title>Boteco – Restaurante Brasileiro</title>
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="assets/images/favicon.ico">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://boteco.co.in/index.html</loc>
+    <loc>https://boteco.co.in/</loc>
   </url>
   <url>
     <loc>https://boteco.co.in/bar-menu.html</loc>


### PR DESCRIPTION
## Summary
- update the canonical link in `index.html` to refer to the site root
- update the first entry in `sitemap.xml` to match

## Testing
- `python3 -m py_compile scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688b6b91f21483269af6f41f164aa881