### PR TITLE
Fix duplicate headings and improve hierarchy

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
                             <img loading="lazy" src="assets/images/food-placeholder.png" class="card-img-top" alt="Delicious dishes">
                         </a>
                         <div class="p-3">
-                            <h5 class="mb-2">Food Menu</h5>
+                            <p class="h5 mb-2">Food Menu</p>
                             <p class="small">A selection of starters, mains and desserts inspired by Brazilian cuisine.</p>
                         </div>
                     </div>
@@ -103,7 +103,7 @@
                             <img loading="lazy" src="assets/images/drinks-placeholder.png" class="card-img-top" alt="Signature drinks">
                         </a>
                         <div class="p-3">
-                            <h5 class="mb-2">Bar Menu</h5>
+                            <p class="h5 mb-2">Bar Menu</p>
                             <p class="small">Signature cocktails, fine wines and craft beers.</p>
                         </div>
                     </div>
@@ -114,7 +114,7 @@
                             <img loading="lazy" src="assets/images/specials-placeholder.png" class="card-img-top" alt="Chef's specials">
                         </a>
                         <div class="p-3">
-                            <h5 class="mb-2">Specials</h5>
+                            <p class="h5 mb-2">Specials</p>
                             <p class="small">Seasonal dishes and chef's creations.</p>
                         </div>
                     </div>
@@ -128,14 +128,14 @@
         <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="foodMenuLabel">Food Menu</h5>
+                    <h3 class="modal-title" id="foodMenuLabel">Food Menu</h3>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="d-flex justify-content-center align-items-center mb-3">
                     <button class="prev-btn btn btn-outline-dark me-3">
                         <i class="fa-solid fa-chevron-left"></i>
                     </button>
-                    <h5 class="mb-0">Food Menu</h5>
+                    <p class="h5 mb-0">Food Menu</p>
                     <div class="image-counter"></div>
                     <button class="next-btn btn btn-outline-dark ms-3">
                         <i class="fa-solid fa-chevron-right"></i>
@@ -186,14 +186,14 @@
         <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="barMenuLabel">Bar Menu</h5>
+                    <h3 class="modal-title" id="barMenuLabel">Bar Menu</h3>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="d-flex justify-content-center align-items-center mb-3">
                     <button class="prev-btn btn btn-outline-dark me-3">
                         <i class="fa-solid fa-chevron-left"></i>
                     </button>
-                    <h5 class="mb-0">Bar Menu</h5>
+                    <p class="h5 mb-0">Bar Menu</p>
                     <div class="image-counter"></div>
                     <button class="next-btn btn btn-outline-dark ms-3">
                         <i class="fa-solid fa-chevron-right"></i>
@@ -256,14 +256,14 @@
         <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="specialsMenuLabel">Specials Menu</h5>
+                    <h3 class="modal-title" id="specialsMenuLabel">Specials Menu</h3>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="d-flex justify-content-center align-items-center mb-3">
                     <button class="prev-btn btn btn-outline-dark me-3">
                         <i class="fa-solid fa-chevron-left"></i>
                     </button>
-                    <h5 class="mb-0">Specials Menu</h5>
+                    <p class="h5 mb-0">Specials Menu</p>
                     <div class="image-counter"></div>
                     <button class="next-btn btn btn-outline-dark ms-3">
                         <i class="fa-solid fa-chevron-right"></i>
@@ -293,7 +293,7 @@
         <div class="modal-dialog modal-xl modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="reservationsModalLabel">Reservations</h5>
+                    <h3 class="modal-title" id="reservationsModalLabel">Reservations</h3>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
@@ -308,7 +308,7 @@
         <div class="modal-dialog modal-xl modal-dialog-centered">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="partyBookingModalLabel">Party / Event Enquiries</h5>
+                    <h3 class="modal-title" id="partyBookingModalLabel">Party / Event Enquiries</h3>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">


### PR DESCRIPTION
## Summary
- remove duplicate heading tags from index page
- bump modal headings to `<h3>` for a consistent outline

## Testing
- `python3 -m py_compile scripts/generate_events_json.py`


------
https://chatgpt.com/codex/tasks/task_e_688b6c0c1d148326b29669d82c0759ce