### PR TITLE
Remove full menu links

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,6 @@
                         <div class="p-3">
                             <p class="h5 mb-2">Food Menu</p>
                             <p class="small">A selection of starters, mains and desserts inspired by Brazilian cuisine.</p>
-                            <a href="food-menu.html" class="nav-link p-0">Full menu</a>
                         </div>
                     </div>
                 </div>
@@ -106,7 +105,6 @@
                         <div class="p-3">
                             <p class="h5 mb-2">Bar Menu</p>
                             <p class="small">Signature cocktails, fine wines and craft beers.</p>
-                            <a href="bar-menu.html" class="nav-link p-0">Full menu</a>
                         </div>
                     </div>
                 </div>
@@ -118,7 +116,6 @@
                         <div class="p-3">
                             <p class="h5 mb-2">Specials</p>
                             <p class="small">Seasonal dishes and chef's creations.</p>
-                            <a href="specials-menu.html" class="nav-link p-0">Full menu</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- remove the links labeled "Full menu" from the home page menu cards

## Testing
- `python3 scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688b6f6f4edc8326905c9bd6e2aa5a91