### PR TITLE
Update About section layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,40 +68,39 @@
     <!-- About Section -->
     <section id="about" class="py-5 about-section">
         <div class="container">
-            <div class="row align-items-center g-4">
-                <div class="col-lg-6">
-                    <!-- Placeholder image representing the cosy interior or team; replace with a photo of your restaurant -->
-                    <img loading="lazy" src="assets/images/about-placeholder.png" alt="Inside Boteco restaurant" class="img-fluid rounded">
-                </div>
-                <div class="col-lg-6">
-                    <h2 class="mb-3">About Us</h2>
-                    <div class="row row-cols-1 row-cols-md-2 g-3">
-                        <div class="col">
-                            <div class="about-tile p-3 h-100">
-                                <p class="h5 mb-2">Our Story: Where It All Began</p>
-                                <p class="small mb-0">Founded in 2015, Boteco is India’s first and only authentic Brazilian restaurant chain. We proudly bring the bold flavors, vibrant spirit, and festive soul of Brazil to the Indian dining scene. Inspired by the colorful streets of Rio de Janeiro and the warm hospitality found across Brazil, Boteco is more than just a place to eat. It is a space where cultures connect, stories are shared, and every visit feels like a celebration.</p>
-                            </div>
-                        </div>
-                        <div class="col">
-                            <div class="about-tile p-3 h-100">
-                                <p class="h5 mb-2">The Boteco Experience</p>
-                                <p class="small mb-0">From the moment guests step inside, they are welcomed into a tropical haven filled with lush plants, handcrafted mosaic murals, and a lively, music-filled atmosphere that reflects Brazil’s rich cultural heritage. Every design element and menu detail is thoughtfully crafted to transport you to the heart of South America and create an immersive, joyful dining experience.</p>
-                            </div>
-                        </div>
-                        <div class="col">
-                            <div class="about-tile p-3 h-100">
-                                <p class="h5 mb-2">Meet the Chef Behind the Magic</p>
-                                <p class="small mb-0">At the center of our kitchen is Executive Chef Guto Souza, whose culinary journey spans over 30 years. A native of São Paulo, Chef Guto brings a wealth of experience, combining tradition with creativity to offer dishes that are both nostalgic and innovative. His passion for authentic Brazilian cooking is the heartbeat of every plate we serve.</p>
-                            </div>
-                        </div>
-                        <div class="col">
-                            <div class="about-tile p-3 h-100">
-                                <p class="h5 mb-2">Our Menu: A Taste of Brazil</p>
-                                <p class="small mb-0">Our menu is a flavorful exploration of Brazilian cuisine, featuring iconic snacks like coxinhas and pão de queijo, comforting stews such as feijoada and moqueca, and an extensive selection of grilled meats inspired by Brazil’s legendary barbecue culture. Our signature churrasco platters are flame-grilled to perfection and served with a variety of sides and sauces. Whether you're joining us for a hearty meal, a quick bite, or a festive gathering, Boteco is where India meets Brazil in a joyful celebration of food, community, and culture.</p>
-                            </div>
-                        </div>
+            <h2 class="text-center mb-4">About Us</h2>
+            <div class="row row-cols-1 row-cols-md-2 g-3 mb-4">
+                <div class="col">
+                    <div class="about-tile p-3 h-100">
+                        <p class="h5 mb-2">Our Story: Where It All Began</p>
+                        <p class="small mb-0">Founded in 2015, Boteco is India’s first and only authentic Brazilian restaurant chain. We proudly bring the bold flavors, vibrant spirit, and festive soul of Brazil to the Indian dining scene. Inspired by the colorful streets of Rio de Janeiro and the warm hospitality found across Brazil, Boteco is more than just a place to eat. It is a space where cultures connect, stories are shared, and every visit feels like a celebration.</p>
                     </div>
                 </div>
+                <div class="col">
+                    <div class="about-tile p-3 h-100">
+                        <p class="h5 mb-2">The Boteco Experience</p>
+                        <p class="small mb-0">From the moment guests step inside, they are welcomed into a tropical haven filled with lush plants, handcrafted mosaic murals, and a lively, music-filled atmosphere that reflects Brazil’s rich cultural heritage. Every design element and menu detail is thoughtfully crafted to transport you to the heart of South America and create an immersive, joyful dining experience.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="text-center mb-4">
+                <!-- Placeholder image representing the cosy interior or team; replace with a photo of your restaurant -->
+                <img loading="lazy" src="assets/images/about-placeholder.png" alt="Inside Boteco restaurant" class="img-fluid rounded">
+            </div>
+            <div class="row row-cols-1 row-cols-md-2 g-3">
+                <div class="col">
+                    <div class="about-tile p-3 h-100">
+                        <p class="h5 mb-2">Meet the Chef Behind the Magic</p>
+                        <p class="small mb-0">At the center of our kitchen is Executive Chef Guto Souza, whose culinary journey spans over 30 years. A native of São Paulo, Chef Guto brings a wealth of experience, combining tradition with creativity to offer dishes that are both nostalgic and innovative. His passion for authentic Brazilian cooking is the heartbeat of every plate we serve.</p>
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="about-tile p-3 h-100">
+                        <p class="h5 mb-2">Our Menu: A Taste of Brazil</p>
+                        <p class="small mb-0">Our menu is a flavorful exploration of Brazilian cuisine, featuring iconic snacks like coxinhas and pão de queijo, comforting stews such as feijoada and moqueca, and an extensive selection of grilled meats inspired by Brazil’s legendary barbecue culture. Our signature churrasco platters are flame-grilled to perfection and served with a variety of sides and sauces. Whether you're joining us for a hearty meal, a quick bite, or a festive gathering, Boteco is where India meets Brazil in a joyful celebration of food, community, and culture.</p>
+                    </div>
+                </div>
+            </div>
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- rearrange the about section to show two info tiles above the placeholder image and two below

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688b75f467a88326ba984a3cab60138e