### PR TITLE
Improve mobile menu modals

### DIFF
--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -365,6 +365,13 @@ footer a:hover {
   margin: 0 0.5rem;
 }
 
+/* Allow pinch zoom within menu carousels on mobile */
+#foodMenuCarousel,
+#barMenuCarousel,
+#specialsMenuCarousel {
+  touch-action: auto;
+}
+
 /* Header awards */
 /* Display awards inline and slightly larger */
 .header-awards {

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
 
     <!-- Food Menu Modal -->
     <div class="modal fade" id="foodMenuModal" tabindex="-1" aria-labelledby="foodMenuLabel" aria-hidden="true">
-        <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable modal-fullscreen-sm-down">
             <div class="modal-content">
                 <div class="modal-header">
                     <h3 class="modal-title" id="foodMenuLabel">Food Menu</h3>
@@ -206,7 +206,7 @@
 
     <!-- Bar Menu Modal -->
     <div class="modal fade" id="barMenuModal" tabindex="-1" aria-labelledby="barMenuLabel" aria-hidden="true">
-        <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable modal-fullscreen-sm-down">
             <div class="modal-content">
                 <div class="modal-header">
                     <h3 class="modal-title" id="barMenuLabel">Bar Menu</h3>
@@ -276,7 +276,7 @@
 
     <!-- Specials Menu Modal -->
     <div class="modal fade" id="specialsMenuModal" tabindex="-1" aria-labelledby="specialsMenuLabel" aria-hidden="true">
-        <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable modal-fullscreen-sm-down">
             <div class="modal-content">
                 <div class="modal-header">
                     <h3 class="modal-title" id="specialsMenuLabel">Specials Menu</h3>


### PR DESCRIPTION
## Summary
- expand menu carousels to fullscreen on phones
- allow pinch zoom on menu modals

## Testing
- `python3 scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688b9e2d3b988326923d4799d7858fe4