### PR TITLE
Add about images grid

### DIFF
--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -405,3 +405,11 @@ footer a:hover {
 .about-tile p {
   color: #545454;
 }
+
+/* About section image grid */
+.about-photo-grid img {
+  width: 100%;
+  height: auto;
+  border-radius: 0.5rem;
+  object-fit: cover;
+}

--- a/assets/js/about-tiles.js
+++ b/assets/js/about-tiles.js
@@ -1,0 +1,28 @@
+(document.addEventListener('DOMContentLoaded', function () {
+  var grid = document.getElementById('about-images-grid');
+  if (!grid) return;
+  var exts = ['.jpg', '.png', '.gif'];
+  var total = 6;
+  for (var i = 1; i <= total; i++) {
+    (function(i){
+      var col = document.createElement('div');
+      col.className = 'col';
+      var img = new Image();
+      img.loading = 'lazy';
+      img.alt = 'Boteco interior image ' + i;
+      img.className = 'img-fluid rounded';
+      var extIndex = 0;
+      function loadNext() {
+        if (extIndex >= exts.length) {
+          img.remove();
+          return;
+        }
+        img.src = 'assets/images/about-us-tile' + i + exts[extIndex++];
+      }
+      img.onerror = loadNext;
+      loadNext();
+      col.appendChild(img);
+      grid.appendChild(col);
+    })(i);
+  }
+}));

--- a/index.html
+++ b/index.html
@@ -83,10 +83,8 @@
                     </div>
                 </div>
             </div>
-            <div class="text-center mb-4">
-                <!-- Placeholder image representing the cosy interior or team; replace with a photo of your restaurant -->
-                <img loading="lazy" src="assets/images/about-placeholder.png" alt="Inside Boteco restaurant" class="img-fluid rounded">
-            </div>
+            <!-- Grid of photos showcasing the restaurant -->
+            <div id="about-images-grid" class="row row-cols-2 row-cols-md-3 g-3 mb-4 about-photo-grid"></div>
             <div class="row row-cols-1 row-cols-md-2 g-3">
                 <div class="col">
                     <div class="about-tile p-3 h-100">
@@ -507,6 +505,7 @@
     <script src="assets/js/header.js" defer></script>
     <script src="assets/js/uniform-menu-heights.js" defer></script>
     <script src="assets/js/carousel-counter.js" defer></script>
+    <script src="assets/js/about-tiles.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace placeholder with grid container
- dynamically load new about images via JS
- style photo grid

## Testing
- `tidy -q -e index.html`

------
https://chatgpt.com/codex/tasks/task_e_688ba37ba9048326958959818de79892