### PR TITLE
Improve about collage load speed

### DIFF
--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -407,9 +407,22 @@ footer a:hover {
 }
 
 /* About section image grid */
+.about-photo-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.75rem;
+  aspect-ratio: 16 / 9;
+}
+
+@media (min-width: 768px) {
+  .about-photo-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
 .about-photo-grid img {
   width: 100%;
-  height: auto;
+  height: 100%;
   border-radius: 0.5rem;
   object-fit: cover;
 }

--- a/index.html
+++ b/index.html
@@ -84,7 +84,14 @@
                 </div>
             </div>
             <!-- Grid of photos showcasing the restaurant -->
-            <div id="about-images-grid" class="row row-cols-2 row-cols-md-3 g-3 mb-4 about-photo-grid"></div>
+            <div id="about-images-grid" class="about-photo-grid mb-4">
+                <img loading="lazy" src="assets/images/about-us-tile1.jpg" alt="Boteco interior image 1" class="rounded">
+                <img loading="lazy" src="assets/images/about-us-tile2.jpg" alt="Boteco interior image 2" class="rounded">
+                <img loading="lazy" src="assets/images/about-us-tile3.jpg" alt="Boteco interior image 3" class="rounded">
+                <img loading="lazy" src="assets/images/about-us-tile4.jpg" alt="Boteco interior image 4" class="rounded">
+                <img loading="lazy" src="assets/images/about-us-tile5.jpg" alt="Boteco interior image 5" class="rounded">
+                <img loading="lazy" src="assets/images/about-us-tile6.jpg" alt="Boteco interior image 6" class="rounded">
+            </div>
             <div class="row row-cols-1 row-cols-md-2 g-3">
                 <div class="col">
                     <div class="about-tile p-3 h-100">
@@ -505,7 +512,6 @@
     <script src="assets/js/header.js" defer></script>
     <script src="assets/js/uniform-menu-heights.js" defer></script>
     <script src="assets/js/carousel-counter.js" defer></script>
-    <script src="assets/js/about-tiles.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load `about-us` images directly in markup
- streamline photo grid styling for uniform sizes
- drop unused script include

## Testing
- `python3 scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688cca23a78483268b8cf2b75e0ad883