### PR TITLE
Adjust About Us image grid size

### DIFF
--- a/assets/css/boteco_style.css
+++ b/assets/css/boteco_style.css
@@ -411,8 +411,7 @@ footer a:hover {
 .about-photo-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 0.75rem;
-  aspect-ratio: 16 / 9;
+  gap: 0.25rem;
 }
 
 @media (min-width: 768px) {
@@ -423,7 +422,7 @@ footer a:hover {
 
 .about-photo-grid img {
   width: 100%;
-  height: 100%;
+  aspect-ratio: 1 / 1;
   border-radius: 0.5rem;
   object-fit: cover;
 }


### PR DESCRIPTION
## Summary
- make About Us grid gap thinner
- square the images to match Instagram sizing

## Testing
- `python3 scripts/generate_events_json.py`

------
https://chatgpt.com/codex/tasks/task_e_688ccd759cb083269014526a6bb7b9c1