### PR TITLE
ci: enable workflow pushes

### DIFF
--- a/.github/workflows/convert-images.yml
+++ b/.github/workflows/convert-images.yml
@@ -8,12 +8,17 @@ on:
       - 'assets/**/*.jpg'
       - 'assets/**/*.jpeg'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -27,13 +32,15 @@ jobs:
         run: python scripts/convert_images_to_webp.py
 
       - name: Commit and push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git status --porcelain | grep '.webp'; then
             git add assets
             git commit -m 'chore: convert images to webp'
-            git push
+            git push origin HEAD:${GITHUB_REF#refs/heads/}
           else
             echo 'No images to convert.'
           fi

--- a/.github/workflows/delete-merged-branches.yml
+++ b/.github/workflows/delete-merged-branches.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 1 * * *'   # Daily at 1 AM UTC
 
+permissions:
+  contents: write
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest
@@ -14,14 +17,15 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # ensure complete history
+          persist-credentials: true
 
       - name: Delete merged branches
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: ${{ github.repository_default_branch }}
         run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git fetch origin --prune
 

--- a/.github/workflows/update-events.yml
+++ b/.github/workflows/update-events.yml
@@ -5,12 +5,17 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: true
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -21,13 +26,15 @@ jobs:
         run: python scripts/generate_events_json.py
 
       - name: Commit and push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if git status --porcelain | grep 'events.json'; then
             git add assets/events/events.json
             git commit -m 'chore: update events.json'
-            git push
+            git push origin HEAD:${GITHUB_REF#refs/heads/}
           else
             echo 'No changes to commit.'
           fi


### PR DESCRIPTION
## Summary
- grant workflows write access to push updates
- persist credentials and standardize `github-actions[bot]` identity

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688daf9ccba48326ad829bce12257fad