### PR TITLE
Skip existing minified JS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "minify:css": "cleancss -o assets/css/boteco_style.min.css assets/css/boteco_style.css",
-    "minify:js": "bash -c 'for file in assets/js/*.js; do uglifyjs \"$file\" -c -m -o \"${file%.js}.min.js\"; done'",
+    "minify:js": "bash -c 'for file in assets/js/*.js; do [[ \"$file\" == *.min.js ]] && continue; uglifyjs \"$file\" -c -m -o \"${file%.js}.min.js\"; done'",
     "build": "npm-run-all minify:css minify:js"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- Skip already minified JavaScript files when running `minify:js`

## Testing
- `npm run minify:js`


------
https://chatgpt.com/codex/tasks/task_e_688db23ceb2c83269565c7f17b443c7e