### PR TITLE
chore: remove invalid main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "boteco-website",
   "version": "1.0.0",
   "description": "This repository contains the static files for the Boteco restaurant website.",
-  "main": "index.js",
   "scripts": {
     "minify:css": "cleancss -o assets/css/boteco_style.min.css assets/css/boteco_style.css",
     "minify:js": "bash -c 'for file in assets/js/*.js; do uglifyjs \"$file\" -c -m -o \"${file%.js}.min.js\"; done'",


### PR DESCRIPTION
## Summary
- remove outdated main field from package.json

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688db23af444832680c46b087b77b548