### PR TITLE
Add placeholder HTML validation test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "minify:css": "cleancss -o assets/css/boteco_style.min.css assets/css/boteco_style.css",
     "minify:js": "bash -c 'for file in assets/js/*.js; do uglifyjs \"$file\" -c -m -o \"${file%.js}.min.js\"; done'",
-    "build": "npm-run-all minify:css minify:js"
+    "build": "npm-run-all minify:css minify:js",
+    "test": "node scripts/validate-html.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/validate-html.js
+++ b/scripts/validate-html.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+// Root directory is one level up from this script
+const rootDir = path.join(__dirname, '..');
+
+// Gather all HTML files in the root directory
+const htmlFiles = fs.readdirSync(rootDir).filter(file => file.endsWith('.html'));
+
+let allValid = true;
+htmlFiles.forEach(file => {
+  const filePath = path.join(rootDir, file);
+  const content = fs.readFileSync(filePath, 'utf8');
+  if (!content.trimStart().toLowerCase().startsWith('<!doctype html>')) {
+    console.error(`${file} is missing <!DOCTYPE html> declaration.`);
+    allValid = false;
+  }
+});
+
+if (!allValid) {
+  console.error('HTML validation failed.');
+  process.exit(1);
+} else {
+  console.log('All HTML files contain a <!DOCTYPE html> declaration.');
+}


### PR DESCRIPTION
## Summary
- ensure `npm test` executes by adding a HTML validation script
- add basic validation to check for missing `<!DOCTYPE html>` declarations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688db256e2f48326b45ee09ba68eb394