### PR TITLE
Fix duplicate event images by preferring webp

### DIFF
--- a/assets/events/events.json
+++ b/assets/events/events.json
@@ -2,11 +2,6 @@
   {
     "date": "2025-08-07",
     "title": "Brazilian Churrasco Night",
-    "image": "2025-08-07-Brazilian-Churrasco-Night.jpg"
-  },
-  {
-    "date": "2025-08-07",
-    "title": "Brazilian Churrasco Night",
     "image": "2025-08-07-Brazilian-Churrasco-Night.webp"
   }
 ]


### PR DESCRIPTION
## Summary
- avoid duplicate event entries when multiple image formats exist
- regenerate events.json to use a single image per event

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68901e8a6cc48326b73b0e3bd0d45d0e