### PR TITLE
Use build-generated asset manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "scripts": {
     "generate:menus": "python scripts/generate_menu_manifest.py",
     "generate:events": "python scripts/generate_events_json.py",
+    "generate:sw-manifest": "node scripts/generate_sw_manifest.js",
     "prefix:css": "postcss assets/css/boteco_style.css --no-map -o assets/css/boteco_style.css",
     "minify:css": "cleancss -o assets/css/boteco_style.min.css assets/css/boteco_style.css",
     "minify:js": "bash -c 'for file in assets/js/*.js; do [[ \"$file\" == *.min.js ]] && continue; uglifyjs \"$file\" -c -m -o \"${file%.js}.min.js\"; done'",
-    "build": "npm-run-all generate:menus generate:events prefix:css minify:css minify:js",
+    "build": "npm-run-all generate:menus generate:events prefix:css minify:css minify:js generate:sw-manifest",
     "lint:js": "eslint assets/js",
     "lint:html": "htmlhint \"**/*.html\" --ignore node_modules/**",
     "lint": "npm-run-all lint:js lint:html",

--- a/precache-manifest.js
+++ b/precache-manifest.js
@@ -1,0 +1,18 @@
+self.__ASSETS_MANIFEST = [
+  "/",
+  "/index.html",
+  "/bar-menu.html",
+  "/food-menu.html",
+  "/party-booking.html",
+  "/specials-menu.html",
+  "/assets/css/boteco_style.min.css",
+  "/assets/js/carousel-counter.min.js",
+  "/assets/js/events.min.js",
+  "/assets/js/fade-in.min.js",
+  "/assets/js/header.min.js",
+  "/assets/js/hero-video.min.js",
+  "/assets/js/menu-gallery.min.js",
+  "/assets/js/uniform-menu-heights.min.js",
+  "/assets/events/archive/archive.json",
+  "/assets/events/events.json"
+];

--- a/scripts/generate_sw_manifest.js
+++ b/scripts/generate_sw_manifest.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.resolve(__dirname, '..');
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  let files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files = files.concat(walk(fullPath));
+    } else {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function toWebPath(filePath) {
+  return '/' + path.relative(rootDir, filePath).replace(/\\/g, '/');
+}
+
+const assets = [
+  '/',
+  '/index.html',
+  '/bar-menu.html',
+  '/food-menu.html',
+  '/party-booking.html',
+  '/specials-menu.html'
+];
+
+const cssDir = path.join(rootDir, 'assets', 'css');
+if (fs.existsSync(cssDir)) {
+  const cssFiles = walk(cssDir).filter(f => f.endsWith('.min.css'));
+  assets.push(...cssFiles.map(toWebPath));
+}
+
+const jsDir = path.join(rootDir, 'assets', 'js');
+if (fs.existsSync(jsDir)) {
+  const jsFiles = walk(jsDir).filter(f => f.endsWith('.min.js'));
+  assets.push(...jsFiles.map(toWebPath));
+}
+
+const eventsDir = path.join(rootDir, 'assets', 'events');
+if (fs.existsSync(eventsDir)) {
+  const eventFiles = walk(eventsDir).filter(f => f.endsWith('.json'));
+  assets.push(...eventFiles.map(toWebPath));
+}
+
+const manifestPath = path.join(rootDir, 'precache-manifest.js');
+const content = `self.__ASSETS_MANIFEST = ${JSON.stringify(assets, null, 2)};\n`;
+fs.writeFileSync(manifestPath, content);

--- a/sw.js
+++ b/sw.js
@@ -1,25 +1,11 @@
 const CACHE_VERSION = 'v1';
 const CACHE_NAME = `boteco-cache-${CACHE_VERSION}`;
 
+// Import build-generated asset manifest
+importScripts('/precache-manifest.js');
+
 // Core assets required for the shell of the site
-const ASSETS = [
-  '/',
-  '/index.html',
-  '/bar-menu.html',
-  '/food-menu.html',
-  '/party-booking.html',
-  '/specials-menu.html',
-  '/assets/css/boteco_style.min.css',
-  '/assets/js/events.min.js',
-  '/assets/js/hero-video.min.js',
-  '/assets/js/header.min.js',
-  '/assets/js/fade-in.min.js',
-  '/assets/js/uniform-menu-heights.min.js',
-  '/assets/js/carousel-counter.min.js',
-  '/assets/js/menu-gallery.min.js',
-  '/assets/events/events.json',
-  '/assets/events/archive/archive.json'
-];
+const ASSETS = self.__ASSETS_MANIFEST || [];
 
 self.addEventListener('install', event => {
   self.skipWaiting();


### PR DESCRIPTION
## Summary
- Replace hardcoded ASSETS list with build-generated manifest in service worker
- Add script to scan assets and write precache-manifest
- Run manifest generation during build

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68909585eec08326a6d56d6db10d3b6d