### PR TITLE
feat: add Expires headers to cached responses

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -34,8 +34,19 @@ self.addEventListener('fetch', event => {
     event.respondWith(
       fetch(request)
         .then(response => {
-          const copy = response.clone();
-          caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
+          if (response.status === 200) {
+            const headers = new Headers(response.headers);
+            const futureDate = new Date();
+            futureDate.setFullYear(futureDate.getFullYear() + 1);
+            headers.set('Expires', futureDate.toUTCString());
+            const modifiedResponse = new Response(response.clone().body, {
+              status: response.status,
+              statusText: response.statusText,
+              headers
+            });
+            caches.open(CACHE_NAME).then(cache => cache.put(request, modifiedResponse.clone()));
+            return modifiedResponse;
+          }
           return response;
         })
         .catch(() => caches.match(request))
@@ -51,8 +62,17 @@ self.addEventListener('fetch', event => {
 
         return fetch(request).then(response => {
           if (response.status === 200) {
-            const copy = response.clone();
-            caches.open(CACHE_NAME).then(cache => cache.put(request, copy));
+            const headers = new Headers(response.headers);
+            const futureDate = new Date();
+            futureDate.setFullYear(futureDate.getFullYear() + 1);
+            headers.set('Expires', futureDate.toUTCString());
+            const modifiedResponse = new Response(response.clone().body, {
+              status: response.status,
+              statusText: response.statusText,
+              headers
+            });
+            caches.open(CACHE_NAME).then(cache => cache.put(request, modifiedResponse.clone()));
+            return modifiedResponse;
           }
           return response;
         });


### PR DESCRIPTION
## Summary
- set `Expires` header on cached navigation responses
- set `Expires` header on cached static asset responses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890de4b0aac8326a12533489ad1b547