### PR TITLE
Allow diffs for binary assets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,18 +1,17 @@
 # Auto-detect text files and enforce Unix-style line endings
 * text=auto eol=lf
 
-# Declare binary file types
-*.png   binary
-*.jpg   binary
-*.jpeg  binary
-*.gif   binary
-*.webp  binary
-*.ico   binary
-*.mp4   binary
-*.webm  binary
-*.ttf   binary
-*.woff  binary
-*.woff2 binary
-*.eot   binary
-*.gz    binary
-*.gz -text
+# Force diff generation for common binary assets without EOL conversions
+*.png -text diff
+*.jpg -text diff
+*.jpeg -text diff
+*.gif -text diff
+*.webp -text diff
+*.ico -text diff
+*.mp4 -text diff
+*.webm -text diff
+*.ttf -text diff
+*.woff -text diff
+*.woff2 -text diff
+*.eot -text diff
+*.gz -text diff


### PR DESCRIPTION
## Summary
- force Git to generate diffs for common binary assets by marking them `-text diff`
- this avoids `Binary files differ` messages so PRs with binary changes can be created

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68918ccfc60883268170adb463dd7371