### PR TITLE
Fix chevron navigation icons on menu pages

### DIFF
--- a/bar-menu.html
+++ b/bar-menu.html
@@ -43,13 +43,17 @@
         <div class="container">
             <div id="barMenuGallery" data-menu-gallery="bar-menu" data-menu-manifest="assets/menus/bar-menu.json" class="menu-gallery mb-4 text-center">
                 <div class="d-flex justify-content-center align-items-center mb-3">
-                    <button class="prev-btn btn btn-outline-dark me-3">
-                        <svg><use href="assets/icons/sprite.svg#chevron-left"></use></svg>
+                    <button class="prev-btn btn btn-outline-dark me-3" aria-label="Previous">
+                        <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                            <path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6Z"/>
+                        </svg>
                     </button>
                     <h1 class="menu-title mb-0">Bar Menu</h1>
                     <div class="image-counter"></div>
-                    <button class="next-btn btn btn-outline-dark ms-3">
-                        <svg><use href="assets/icons/sprite.svg#chevron-right"></use></svg>
+                    <button class="next-btn btn btn-outline-dark ms-3" aria-label="Next">
+                        <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                            <path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6Z"/>
+                        </svg>
                     </button>
                 </div>
                 <div class="position-relative d-inline-block">

--- a/food-menu.html
+++ b/food-menu.html
@@ -43,13 +43,17 @@
         <div class="container">
             <div id="foodMenuGallery" data-menu-gallery="food-menu" data-menu-manifest="assets/menus/food-menu.json" class="menu-gallery mb-4 text-center">
                 <div class="d-flex justify-content-center align-items-center mb-3">
-                    <button class="prev-btn btn btn-outline-dark me-3">
-                        <svg><use href="assets/icons/sprite.svg#chevron-left"></use></svg>
+                    <button class="prev-btn btn btn-outline-dark me-3" aria-label="Previous">
+                        <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                            <path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6Z"/>
+                        </svg>
                     </button>
                     <h1 class="menu-title mb-0">Food Menu</h1>
                     <div class="image-counter"></div>
-                    <button class="next-btn btn btn-outline-dark ms-3">
-                        <svg><use href="assets/icons/sprite.svg#chevron-right"></use></svg>
+                    <button class="next-btn btn btn-outline-dark ms-3" aria-label="Next">
+                        <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                            <path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6Z"/>
+                        </svg>
                     </button>
                 </div>
                 <div class="position-relative d-inline-block">

--- a/index.html
+++ b/index.html
@@ -207,13 +207,17 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="d-flex justify-content-center align-items-center mb-3">
-                    <button class="prev-btn btn btn-outline-dark me-3">
-                        <svg><use href="assets/icons/sprite.svg#chevron-left"></use></svg>
+                    <button class="prev-btn btn btn-outline-dark me-3" aria-label="Previous">
+                        <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                            <path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6Z"/>
+                        </svg>
                     </button>
                     <p class="h5 mb-0">Food Menu</p>
                     <div class="image-counter"></div>
-                    <button class="next-btn btn btn-outline-dark ms-3">
-                        <svg><use href="assets/icons/sprite.svg#chevron-right"></use></svg>
+                    <button class="next-btn btn btn-outline-dark ms-3" aria-label="Next">
+                        <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                            <path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6Z"/>
+                        </svg>
                     </button>
                 </div>
                 <div class="modal-body">
@@ -285,13 +289,17 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="d-flex justify-content-center align-items-center mb-3">
-                    <button class="prev-btn btn btn-outline-dark me-3">
-                        <svg><use href="assets/icons/sprite.svg#chevron-left"></use></svg>
+                    <button class="prev-btn btn btn-outline-dark me-3" aria-label="Previous">
+                        <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                            <path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6Z"/>
+                        </svg>
                     </button>
                     <p class="h5 mb-0">Bar Menu</p>
                     <div class="image-counter"></div>
-                    <button class="next-btn btn btn-outline-dark ms-3">
-                        <svg><use href="assets/icons/sprite.svg#chevron-right"></use></svg>
+                    <button class="next-btn btn btn-outline-dark ms-3" aria-label="Next">
+                        <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                            <path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6Z"/>
+                        </svg>
                     </button>
                 </div>
                 <div class="modal-body">
@@ -383,13 +391,17 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="d-flex justify-content-center align-items-center mb-3">
-                    <button class="prev-btn btn btn-outline-dark me-3">
-                        <svg><use href="assets/icons/sprite.svg#chevron-left"></use></svg>
+                    <button class="prev-btn btn btn-outline-dark me-3" aria-label="Previous">
+                        <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                            <path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6Z"/>
+                        </svg>
                     </button>
                     <p class="h5 mb-0">Specials Menu</p>
                     <div class="image-counter"></div>
-                    <button class="next-btn btn btn-outline-dark ms-3">
-                        <svg><use href="assets/icons/sprite.svg#chevron-right"></use></svg>
+                    <button class="next-btn btn btn-outline-dark ms-3" aria-label="Next">
+                        <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                            <path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6Z"/>
+                        </svg>
                     </button>
                 </div>
                 <div class="modal-body">

--- a/specials-menu.html
+++ b/specials-menu.html
@@ -43,13 +43,17 @@
         <div class="container">
             <div id="specialsMenuGallery" data-menu-gallery="specials-menu" data-menu-manifest="assets/menus/specials-menu.json" class="menu-gallery mb-4 text-center">
                 <div class="d-flex justify-content-center align-items-center mb-3">
-                    <button class="prev-btn btn btn-outline-dark me-3">
-                        <svg><use href="assets/icons/sprite.svg#chevron-left"></use></svg>
+                    <button class="prev-btn btn btn-outline-dark me-3" aria-label="Previous">
+                        <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                            <path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6Z"/>
+                        </svg>
                     </button>
                     <h1 class="menu-title mb-0">Specials Menu</h1>
                     <div class="image-counter"></div>
-                    <button class="next-btn btn btn-outline-dark ms-3">
-                        <svg><use href="assets/icons/sprite.svg#chevron-right"></use></svg>
+                    <button class="next-btn btn btn-outline-dark ms-3" aria-label="Next">
+                        <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true">
+                            <path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6Z"/>
+                        </svg>
                     </button>
                 </div>
                 <div class="position-relative d-inline-block">


### PR DESCRIPTION
## Summary
- inline chevron SVGs so menu navigation icons render
- add aria labels to menu navigation buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68919b5f9aa08326a999f06c74015502