### PR TITLE
chore: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Build site
+        run: npm run build
+      - name: Remove dependencies
+        run: rm -rf node_modules
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ This repository contains the static files for the Boteco restaurant website.
 
 8. Commit the resulting changes and deploy.
 
+## Deployment
+
+Pushing to the `main` branch triggers a GitHub Actions workflow that installs dependencies, builds the site, and publishes the result to GitHub Pages. For manual deployments, run `npm run build` before pushing so the published files are up to date.
+
 ## Security
 
 External CDN resources are loaded with [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) attributes to ensure the assets have not been tampered with. Event titles are inserted using the DOM API to prevent cross-site scripting.


### PR DESCRIPTION
## Summary
- add workflow to build and deploy the site to GitHub Pages on pushes to `main`
- document that manual deployments run `npm run build`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891a6910cec8326939bb9e7827774f2