### PR TITLE
Add sandbox to modal iframes

### DIFF
--- a/index.html
+++ b/index.html
@@ -466,7 +466,7 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <iframe data-src="https://tinyurl.com/26vp8xgh" title="Reservations" frameborder="0" style="width: 100%; height: 80vh;"></iframe>
+                    <iframe data-src="https://tinyurl.com/26vp8xgh" title="Reservations" frameborder="0" style="width: 100%; height: 80vh;" sandbox="allow-scripts allow-forms"></iframe>
                 </div>
             </div>
         </div>
@@ -481,7 +481,7 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <iframe data-src="https://forms.gle/Ai1X4G6gbpuwKEr97" title="Party Enquiry Form" frameborder="0" style="width: 100%; height: 80vh;" allowfullscreen></iframe>
+                    <iframe data-src="https://forms.gle/Ai1X4G6gbpuwKEr97" title="Party Enquiry Form" frameborder="0" style="width: 100%; height: 80vh;" sandbox="allow-scripts allow-forms"></iframe>
                 </div>
             </div>
         </div>
@@ -496,7 +496,7 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <iframe id="eventLinkIframe" data-src="" title="Event Link" frameborder="0" style="width: 100%; height: 80vh;" allowfullscreen></iframe>
+                    <iframe id="eventLinkIframe" data-src="" title="Event Link" frameborder="0" style="width: 100%; height: 80vh;" sandbox="allow-scripts allow-forms" allowfullscreen></iframe>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- sandbox reservation modal iframe and restrict to scripts and forms
- sandbox party booking and event link modals, limiting iframe capabilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891e104d2cc8326bfbb376c8b36138b