### PR TITLE
Fix modal forms blocked by CSP

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <meta property="og:title" content="Boteco – Restaurante Brasileiro">
     <meta property="og:description" content="Boteco is a cosy Brazilian restaurant in Bengaluru serving authentic dishes, cocktails and live events.">
     <meta property="og:image" content="assets/images/hero.jpg">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.lightwidget.com 'sha256-xsTwv+hPtBRIjfoKhMEFPe2LC5flup2rGTcIbkEJfpI=' 'sha256-35d0SlVNbsG5huKZClI8Hfa362PZ63g/Yhx/mdyCYqU='; style-src 'self' 'unsafe-inline'; frame-src 'self' https://tinyurl.com https://forms.gle https://cdn.lightwidget.com https://www.google.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdn.lightwidget.com 'sha256-xsTwv+hPtBRIjfoKhMEFPe2LC5flup2rGTcIbkEJfpI=' 'sha256-35d0SlVNbsG5huKZClI8Hfa362PZ63g/Yhx/mdyCYqU='; style-src 'self' 'unsafe-inline'; frame-src 'self' https://tinyurl.com https://forms.gle https://cdn.lightwidget.com https://www.google.com https://docs.google.com https://reservations.petpooja.com;">
     <script type="application/ld+json">
     {
         "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- allow external modal form iframes by adding docs.google.com and reservations.petpooja.com to Content Security Policy

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891e710c8e88326b4980c8b0111ba69